### PR TITLE
Modified OpenAlex chart

### DIFF
--- a/api/config_template.cfg
+++ b/api/config_template.cfg
@@ -17,7 +17,8 @@ WORKDAY = 'https://hhmionline.sharepoint.com/SitePages/Search/JanelianUserProfil
 
 EMAIL = 'svirskasr@hhmi.org'
 
-PREFERRED_AFF = "Janelia Research Campus, Howard Hughes Medical Institute, Ashburn, VA"
+PREFERRED_AFF = ["Janelia Research Campus, Howard Hughes Medical Institute, Ashburn, VA",
+                 "Janelia Research Campus, Howard Hughes Medical Institute, Ashburn, VA, USA"]
 SOURCES = ["Crossref", "DataCite"]
 DO_NOT_DISPLAY = ['jrc_acknowledge', 'jrc_author', 'jrc_first_id', 'jrc_last_id', 'jrc_fulltext_url', 'jrc_is_oa', 'jrc_mesh', 'jrc_inserted', 'jrc_newsletter', 'jrc_publishing_date', 'jrc_tag', 'jrc_updated']
 ARTICLES = ["journal-article", "posted-content", "Dataset"]

--- a/api/dis_plots.py
+++ b/api/dis_plots.py
@@ -156,7 +156,8 @@ def pie_chart(data, title, legend, height=300, width=400, location="right", colo
     return components(plt)
 
 
-def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height=None, yaxis2=None):
+def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height=None,
+                      orient=None,yaxis2=None):
     ''' Create a stacked bar chart
         Keyword arguments:
           data: dictionary of data
@@ -166,6 +167,7 @@ def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height
           colors: list of colors (optional)
           width: width of chart (optional)
           height: height of chart (optional)
+          orient: orientation of x-axis labels (optional)
           yaxis2: extra y-axis column name (optional)
         Returns:
           Figure components
@@ -181,6 +183,8 @@ def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height
     plt.vbar_stack(yaxis, x=xaxis, width=0.9,
                    color=colors, source=data,
                    legend_label=yaxis)
+    if orient:
+        plt.xaxis.major_label_orientation = orient
     if yaxis2:
         # Secondary linear plot
         plt.add_tools(HoverTool(tooltips=f"$name @{yaxis2}: @$name"))


### PR DESCRIPTION
Updated OpenAlex chart - citation counts from OpenAlex are used, but the open/closed counts now come from our database. This gets rid of issues with lag and the fact that OpenAlex doesn't know if we published an open article in a closed journal.
Also added plot option to rotate x-avis entries.

@stuarteberg 