### PR TITLE
Graphs

### DIFF
--- a/api/dis_plots.py
+++ b/api/dis_plots.py
@@ -7,13 +7,89 @@ import json
 from math import ceil, pi
 import numpy as np
 from bokeh.colors import named as _bokeh_named
-from bokeh.models import (BasicTicker, ColorBar, HoverTool, LabelSet, LinearAxis,
-                          LinearColorMapper, ColumnDataSource, NumeralTickFormatter, Range1d)
+from bokeh.models import (BasicTicker, ColorBar, CustomJS, HoverTool, LabelSet, LinearAxis,
+                          LinearColorMapper, ColumnDataSource, NumeralTickFormatter, Range1d,
+                          TapTool)
 from bokeh.embed import components
 from bokeh.palettes import all_palettes, plasma, Turbo256
 from bokeh.plotting import figure
 from bokeh.transform import cumsum, transform
 import pandas as pd
+
+
+# Tap-to-navigate callback shared by the bar charts. Clicking a glyph either
+# follows a URL (GET) or submits a hidden form to /doiui/custom (POST, the app's
+# DOI drill-down endpoint, which is POST-only). Inputs are set as DOM properties
+# (not interpolated HTML) so labels with quotes/ampersands can't break the form.
+_NAV_TAP_JS = """
+    const inds = cb_obj.indices;
+    if (!inds || !inds.length) { return; }
+    const d = src.data;
+    const i = inds[0];
+    const url = d['_nav_url'][i];
+    if (url) { window.location.href = url; return; }
+    const field = d['_nav_field'][i];
+    if (!field) { return; }
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/doiui/custom';
+    form.style.display = 'none';
+    const add = (n, v) => {
+        const e = document.createElement('input');
+        e.type = 'hidden';
+        e.name = n;
+        e.value = v;
+        form.appendChild(e);
+    };
+    add('field', field);
+    add('value', d['_nav_value'][i]);
+    if (d['_nav_source'][i]) { add('jrc_obtained_from', d['_nav_source'][i]); }
+    document.body.appendChild(form);
+    form.submit();
+"""
+
+
+def _make_clickable(plot, source, keys, nav, renderers=None):
+    ''' Wire a TapTool so clicking a glyph navigates to a drill-down target.
+        Keyword arguments:
+          plot:      the Bokeh figure
+          source:    the ColumnDataSource backing the glyphs
+          keys:      list of category keys aligned to the source rows
+          nav:       dict mapping a key (matched by str()) to either a URL string
+                     (GET navigation) or a dict {"field":.., "value":.., "source":..}
+                     (POST to /doiui/custom). Keys with no entry stay inert.
+          renderers: glyph renderers the TapTool should hit (default: all)
+        Adds hidden _nav_* columns to `source` and a tap callback. No-op when
+        `nav` is falsy. Must be called before components().
+    '''
+    if not nav:
+        return
+    urls, fields, values, sources = [], [], [], []
+    for key in keys:
+        target = nav.get(str(key))
+        if isinstance(target, str):
+            urls.append(target)
+            fields.append("")
+            values.append("")
+            sources.append("")
+        elif isinstance(target, dict):
+            urls.append("")
+            fields.append(str(target.get("field", "")))
+            values.append(str(target.get("value", "")))
+            sources.append(str(target.get("source", "")))
+        else:
+            urls.append("")
+            fields.append("")
+            values.append("")
+            sources.append("")
+    source.data["_nav_url"] = urls
+    source.data["_nav_field"] = fields
+    source.data["_nav_value"] = values
+    source.data["_nav_source"] = sources
+    plot.add_tools(TapTool(renderers=renderers) if renderers else TapTool())
+    source.selected.js_on_change('indices', CustomJS(args={"src": source},
+                                                     code=_NAV_TAP_JS))
+
 
 def _darken_color(color, factor=0.7):
     ''' Return a darkened version of a CSS named or hex color.
@@ -292,7 +368,7 @@ def pie_chart(data, title, legend, height=300, width=400, location="right",
 
 
 def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height=None,
-                      orient=None, yaxis2=None, tooltip=None, legend=True):
+                      orient=None, yaxis2=None, tooltip=None, legend=True, nav=None):
     ''' Create a stacked bar chart
         Keyword arguments:
           data: dictionary of data
@@ -317,13 +393,14 @@ def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height
     if width and height:
         plt.width = width
         plt.height = height
+    cds = ColumnDataSource(data)
     if legend:
         bar_renderers = plt.vbar_stack(yaxis, x=xaxis, width=0.9,
-                                       color=colors, source=data,
+                                       color=colors, source=cds,
                                        legend_label=yaxis)
     else:
         bar_renderers = plt.vbar_stack(yaxis, x=xaxis, width=0.9,
-                                       color=colors, source=data)
+                                       color=colors, source=cds)
     plt.add_tools(HoverTool(renderers=bar_renderers, tooltips=tt))
     if orient:
         plt.xaxis.major_label_orientation = orient
@@ -340,11 +417,11 @@ def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height
         plt.extra_y_ranges = {yaxis2: Range1d(start=0, end=ymax)}
         plt.add_layout(LinearAxis(y_range_name=yaxis2, axis_label=yaxis2), 'right')
         if legend:
-            line_renderer = plt.line(xaxis, yaxis2, color="black", source=data,
+            line_renderer = plt.line(xaxis, yaxis2, color="black", source=cds,
                                      line_width=2, legend_label=yaxis2,
                                      y_range_name=yaxis2)
         else:
-            line_renderer = plt.line(xaxis, yaxis2, color="black", source=data,
+            line_renderer = plt.line(xaxis, yaxis2, color="black", source=cds,
                                      line_width=2, y_range_name=yaxis2)
         plt.add_tools(HoverTool(renderers=[line_renderer],
                                 tooltips=f"@{xaxis}: @{yaxis2}"))
@@ -355,6 +432,7 @@ def stacked_bar_chart(data, title, xaxis, yaxis, colors=None, width=None, height
     plt.xgrid.grid_line_color = None
     plt.y_range.start = 0
     plt.background_fill_color = "ghostwhite"
+    _make_clickable(plt, cds, list(data[xaxis]), nav, renderers=bar_renderers)
     return components(plt)
 
 
@@ -374,6 +452,7 @@ def dual_axis_chart(  # pylint: disable=too-many-arguments,too-many-positional-a
     height=450,
     bar_trend=False,
     trend_color="firebrick",
+    nav=None,
 ):
     """
     Generate Bokeh chart script and div for a dual-axis chart with a
@@ -450,6 +529,7 @@ def dual_axis_chart(  # pylint: disable=too-many-arguments,too-many-positional-a
     # --- Legend ---
     p.legend.location = "top_left"
     p.legend.click_policy = "hide"
+    _make_clickable(p, source, x_vals, nav, renderers=[bars])
     chartscript, chartdiv = components(p)
     return chartscript, chartdiv
 
@@ -672,7 +752,7 @@ def heat_map(data, title, x_field, y_field, value_field, width=950, height=500,
 
 
 def hbar_chart(data, title, value_label="Value", width=650, height=450,  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
-               color=None, value_format="$0,0", show_pct=True, show_values=False):
+               color=None, value_format="$0,0", show_pct=True, show_values=False, nav=None):
     ''' Create a horizontal bar chart sorted by value (largest at top).
         Accommodates many categories in a fixed footprint and makes relative
         magnitudes easy to compare by bar length.
@@ -731,6 +811,7 @@ def hbar_chart(data, title, value_label="Value", width=650, height=450,  # pylin
     if show_pct:
         tooltips.append(("% of total", "@pct{0.0}%"))
     p.add_tools(HoverTool(renderers=[bars], tooltips=tooltips))
+    _make_clickable(p, source, labels, nav, renderers=[bars])
     return components(p)
 
 

--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -37,7 +37,7 @@ import dis_plots as DP
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,too-many-lines,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
 
-__version__ = "119.23.0"
+__version__ = "119.24.0"
 # Database
 DB = {}
 CVTERM = {}
@@ -5741,6 +5741,7 @@ def dois_time(period, year=None):
                                message=error_message(err))
     counter = collections.defaultdict(lambda: 0, {})
     trows = []
+    nav = {}
     if period == 'year':
         periods = {}
         for row in rows:
@@ -5766,6 +5767,8 @@ def dois_time(period, year=None):
                     data[source].insert(0, 0)
                     cells.append("")
             trows.append(cells)
+        # Tap a year bar -> all DOIs published that year (mirrors the year cell)
+        nav = {y: {"field": "publishing_year", "value": y} for y in data['years']}
         title = "DOIs published by year"
         chart_title = "DOIs published by year/source"
         pulldown = year_pulldown('dois_time/year')
@@ -5786,6 +5789,10 @@ def dois_time(period, year=None):
                 else:
                     cells.append("")
             trows.append(cells)
+        # Tap a month bar -> all DOIs published that year-month
+        if year and year != 'All':
+            nav = {m: {"field": "publishing_year", "value": f"{year}-{m}"}
+                   for m in data['months']}
         title = f"DOIs published by month for {year}"
         chart_title = title
         pulldown = year_pulldown('dois_time/month', all_years=False)
@@ -5797,7 +5804,7 @@ def dois_time(period, year=None):
     xaxis = 'years' if period == 'year' else 'months'
     chartscript, chartdiv = DP.stacked_bar_chart(data, chart_title, xaxis=xaxis,
                                                  yaxis=app.config['SOURCES'],
-                                                 colors=DP.SOURCE_PALETTE)
+                                                 colors=DP.SOURCE_PALETTE, nav=nav)
     endpoint_access()
     return make_response(render_template('bokeh.html', urlroot=request.url_root,
                                          title=title, html=html,
@@ -6937,11 +6944,14 @@ def citation_metrics(source='datacite'):
                                         width=500, colors=colors)
         chartscript += script
     if ydata['Year']:
+        # Tap a year bar -> the DOIs published that year for this registrar
+        ynav = {yr: {"field": "publishing_year", "value": yr, "source": obtained}
+                for yr in ydata['Year']}
         script, year_div = DP.dual_axis_chart(ydata, title="Citations by publishing year",
                                               x_field='Year', bar_field='Citations',
                                               line_field='Cited', line_label='% cited',
                                               bar_format="0,0", line_format="0%",
-                                              width=650, height=400)
+                                              width=650, height=400, nav=ynav)
         chartscript += script
     # Cards (with freshness/version notes) on their own full-width rows, then
     # each table paired with its chart in a flex row so the chart lines up
@@ -7195,11 +7205,13 @@ def figshare_metrics(year='All'):  # pylint: disable=too-many-locals,too-many-br
                                      fmt="{0,0}")
     chartscript += script
     if ydata['Year']:
+        # Tap a year bar -> figshare metrics scoped to that year
+        ynav = {yr: f"/figshare_stats/{yr}" for yr in ydata['Year']}
         script, year_div = DP.dual_axis_chart(
             ydata, title="Deposits & downloads by year", x_field='Year',
             bar_field='DOIs', line_field='Downloads', bar_label='DOIs deposited',
             line_label='Downloads', bar_color='darkorange', bar_format="0,0",
-            line_format="0,0", width=650, height=400)
+            line_format="0,0", width=650, height=400, nav=ynav)
         chartscript += script
     script, type_div = DP.hbar_chart(type_data, "DOIs by resource type",
                                      value_label="DOIs", width=500, height=320,
@@ -7415,11 +7427,14 @@ def figshare_groups(year='All'):  # pylint: disable=too-many-locals,too-many-bra
     cnthtml = "<h4>Title groups by DOI count (top 20)</h4>" \
               + group_table(by_cnt, 'fig-grp-cnt')
     def chart_data(ordered, value_key):
-        ''' Build {label: value} for a chart. Shorten long stems with a middle
-            ellipsis (keeps the distinguishing tail, e.g. "...P7 mouse skin")
-            so same-prefixed series stay readable; a uniqueness guard prevents
-            two labels from colliding and silently dropping a bar. '''
+        ''' Build {label: value} and a parallel {label: drill-down URL} for a
+            chart. Shorten long stems with a middle ellipsis (keeps the
+            distinguishing tail, e.g. "...P7 mouse skin") so same-prefixed series
+            stay readable; a uniqueness guard prevents two labels from colliding
+            and silently dropping a bar. The nav map carries the full (untruncated)
+            stem so a bar tap reaches the same ?stem= page as the table row. '''
         data = {}
+        nav = {}
         for grp in ordered[:15]:
             value = grp[value_key]
             if value_key == 'downloads' and not value:
@@ -7429,19 +7444,20 @@ def figshare_groups(year='All'):  # pylint: disable=too-many-locals,too-many-bra
             while label in data:
                 label += ' '
             data[label] = value
-        return data
-    grp_dl_data = chart_data(by_dl, 'downloads')
-    grp_cnt_data = chart_data(by_cnt, 'count')
+            nav[label] = f"{base}?stem={quote(stem)}"
+        return data, nav
+    grp_dl_data, grp_dl_nav = chart_data(by_dl, 'downloads')
+    grp_cnt_data, grp_cnt_nav = chart_data(by_cnt, 'count')
     chartscript = dl_div = cnt_div = ''
     if grp_dl_data:
         script, dl_div = DP.hbar_chart(grp_dl_data, "Top title groups by downloads",
                                        value_label="Downloads", width=620, height=420,
-                                       value_format="0,0", show_values=True)
+                                       value_format="0,0", show_values=True, nav=grp_dl_nav)
         chartscript += script
     if grp_cnt_data:
         script, cnt_div = DP.hbar_chart(grp_cnt_data, "Top title groups by DOI count",
                                         value_label="DOIs", width=620, height=420,
-                                        value_format="0,0", show_values=True)
+                                        value_format="0,0", show_values=True, nav=grp_cnt_nav)
         chartscript += script
 
     def flexrow(table_html, chart_div):
@@ -7688,10 +7704,13 @@ def zenodo_groups(year='All'):  # pylint: disable=too-many-locals,too-many-branc
               + group_table(by_cit, 'zen-grp-cit')
 
     def chart_data(ordered, value_key):
-        ''' Build {label: value} for a chart, shortening long labels with a middle
-            ellipsis; a uniqueness guard stops two labels colliding and silently
-            dropping a bar. '''
+        ''' Build {label: value} and a parallel {label: drill-down URL} for a
+            chart, shortening long labels with a middle ellipsis; a uniqueness
+            guard stops two labels colliding and silently dropping a bar. The nav
+            map carries the deposit concept so a bar tap reaches the same ?concept=
+            page as the table row. '''
         data = {}
+        nav = {}
         for grp in ordered[:15]:
             value = grp[value_key]
             if value_key in ('downloads', 'citations') and not value:
@@ -7701,25 +7720,26 @@ def zenodo_groups(year='All'):  # pylint: disable=too-many-locals,too-many-branc
             while label in data:
                 label += ' '
             data[label] = value
-        return data
-    grp_dl_data = chart_data(by_dl, 'downloads')
-    grp_cnt_data = chart_data(by_cnt, 'count')
-    grp_cit_data = chart_data(by_cit, 'citations')
+            nav[label] = f"{base}?concept={quote(grp['concept'])}"
+        return data, nav
+    grp_dl_data, grp_dl_nav = chart_data(by_dl, 'downloads')
+    grp_cnt_data, grp_cnt_nav = chart_data(by_cnt, 'count')
+    grp_cit_data, grp_cit_nav = chart_data(by_cit, 'citations')
     chartscript = dl_div = cnt_div = cit_div = ''
     if grp_dl_data:
         script, dl_div = DP.hbar_chart(grp_dl_data, "Top deposits by downloads",
                                        value_label="Downloads", width=620, height=420,
-                                       value_format="0,0", show_values=True)
+                                       value_format="0,0", show_values=True, nav=grp_dl_nav)
         chartscript += script
     if grp_cnt_data:
         script, cnt_div = DP.hbar_chart(grp_cnt_data, "Top deposits by version count",
                                         value_label="Versions", width=620, height=420,
-                                        value_format="0,0", show_values=True)
+                                        value_format="0,0", show_values=True, nav=grp_cnt_nav)
         chartscript += script
     if grp_cit_data:
         script, cit_div = DP.hbar_chart(grp_cit_data, "Top deposits by citations",
                                         value_label="Citations", width=620, height=420,
-                                        value_format="0,0", show_values=True)
+                                        value_format="0,0", show_values=True, nav=grp_cit_nav)
         chartscript += script
 
     def flexrow(table_html, chart_div):
@@ -7882,11 +7902,13 @@ def zenodo_stats(year='All'):  # pylint: disable=too-many-locals,too-many-branch
                                          fmt="{0,0}")
         chartscript += script
     if ydata['Year']:
+        # Tap a year bar -> Zenodo metrics scoped to that year
+        ynav = {yr: f"/zenodo_stats/{yr}" for yr in ydata['Year']}
         script, year_div = DP.dual_axis_chart(
             ydata, title="Deposits & downloads by year", x_field='Year',
             bar_field='DOIs', line_field='Downloads', bar_label='DOIs deposited',
             line_label='Downloads', bar_color='darkorange', bar_format="0,0",
-            line_format="0,0", width=650, height=400)
+            line_format="0,0", width=650, height=400, nav=ynav)
         chartscript += script
     script, type_div = DP.hbar_chart(type_data, "DOIs by resource type",
                                      value_label="DOIs", width=500, height=320,
@@ -8620,9 +8642,11 @@ def org_year(org="Shared Resources"):
                                 fcell(safe(c2), header=False)]) + "<br>"
     data[f"With {org} authors"] = data.pop(org)
     data[f"No {org} authors"] = data.pop("Janelia")
+    # Tap a year bar -> all Janelia last-author pubs that year (mirrors the "All" cell)
+    nav = {yr: f"/org_summary/all/{yr}/last" for yr in data['years']}
     chartscript, chartdiv = DP.stacked_bar_chart(data, title, xaxis="years",
                                                  yaxis=(f"No {org} authors", f"With {org} authors"),
-                                                 colors=DP.SOURCE_PALETTE)
+                                                 colors=DP.SOURCE_PALETTE, nav=nav)
     endpoint_access()
     return make_response(render_template('bokeh.html', urlroot=request.url_root,
                                          title=title, html=html,
@@ -8743,10 +8767,12 @@ def dois_preprint_year():
                         css='tablesorter numbers-scroll',
                         footer=[fcell('Total'), fcell(f"{jrn:,}", align='center'),
                                 fcell(f"{pre:,}", align='center')])
+    # Tap a year bar -> the DOIs published that year
+    ynav = {yr: {"field": "publishing_year", "value": yr} for yr in data['years']}
     chartscript, chartdiv = DP.stacked_bar_chart(data, "DOIs published by year/preprint status",
                                                  xaxis="years",
                                                  yaxis=('Journal article', 'Preprint'),
-                                                 colors=DP.SOURCE_PALETTE)
+                                                 colors=DP.SOURCE_PALETTE, nav=ynav)
     endpoint_access()
     return make_response(render_template('bokeh.html', urlroot=request.url_root,
                                          title="DOIs preprint status by year", html=html,
@@ -9122,10 +9148,12 @@ def show_open_access():
             + "<a href='https://api.openalex.org/institutions?search=Janelia' " \
             + "target='_blank'>OpenAlex</a>"
     tt = [("Year", "@years"), ("Open", "@Open"), ("Closed", "@Closed"), ("Citations", "@Citations")]
+    # Tap a year bar -> the DOIs published that year
+    ynav = {yr: {"field": "publishing_year", "value": yr} for yr in data['years']}
     chartscript, chartdiv = DP.stacked_bar_chart(data, 'OpenAlex DOIs', xaxis="years", orient=pi/4,
                                                  width=900, height=550,
                                                  yaxis=('Closed', 'Open'), yaxis2='Citations',
-                                                 colors=['maroon', 'green'], tooltip=tt)
+                                                 colors=['maroon', 'green'], tooltip=tt, nav=ynav)
     endpoint_access()
     return make_response(render_template('bokeh.html', urlroot=request.url_root,
                                          title="DOIs/citations by year", html=html,
@@ -9780,8 +9808,10 @@ def show_subscription_year(year=None):
     html += stat_cards([("Providers", f"{len(data):,}"),
                         ("Subscriptions", f"{sub_cnt:,}"),
                         ("Total cost", f"${total:,.2f}")], div_id='subyear-stats')
+    # Tap a provider bar -> that provider's cost-by-year report
+    pnav = {prov: f"/subscription/cost/{quote(prov, safe='')}" for prov in data}
     barscript, bardiv = DP.hbar_chart(data, f'Subscription costs by provider for {year}',
-                                      value_label='Cost', width=650, height=450)
+                                      value_label='Cost', width=650, height=450, nav=pnav)
     endpoint_access()
     return make_response(render_template('bokeh.html', urlroot=request.url_root,
                                         title=f"Subscription costs by provider for {year}",
@@ -9909,10 +9939,11 @@ def show_subscription_costs(provider=None):
         html += "<br><br><h3>Providers</h3>"
         html += '<br>'.join([f"<a href='/subscription/cost/{pp}'>{pp}</a>" \
                 for pp in providers])
-    # Bar/line chart
+    # Bar/line chart; tap a year bar -> that year's costs (mirrors the year cell)
+    ynav = {str(yr): f"/subscription/year/{yr}" for yr in data['Year']}
     chartscript, chartdiv = DP.dual_axis_chart(data, title=title,
                                                x_field='Year', bar_field='Cost',
-                                               line_field='Count', bar_trend=True)
+                                               line_field='Count', bar_trend=True, nav=ynav)
     chartscript2 = None
     try:
         if provider:

--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -246,23 +246,32 @@ def before_request():
         app.config["dis"] = JRC.simplenamespace_to_dict(_load_config_ns("dis"))
         print(f"Connecting to {dbo.client} prod")
         try:
-            DB['dis'] = JRC.connect_database(dbo)
+            dis_db = JRC.connect_database(dbo)
         except Exception as err:
             return render_template('warning.html', urlroot=request.url_root,
                                    title=render_warning("Database connect error"), message=err)
+        # Build CVTERM/PROJECT into locals and commit (along with DB['dis']) only
+        # after every read succeeds. This keeps init atomic: a transient failure
+        # here leaves DB empty so the next request retries, instead of leaving the
+        # app permanently running with an unpopulated CVTERM.
         try:
-            rows = DB['dis']['cvterm'].find({})
+            local_cvterm = {}
+            rows = dis_db['cvterm'].find({})
             for row in rows:
-                if row['cv'] not in CVTERM:
-                    CVTERM[row['cv']] = {}
-                CVTERM[row['cv']][row['name']] = row
-            rows = DB['dis'].project_map.find({"doNotUse": {"$exists": False}})
+                if row['cv'] not in local_cvterm:
+                    local_cvterm[row['cv']] = {}
+                local_cvterm[row['cv']][row['name']] = row
+            local_project = {}
+            rows = dis_db.project_map.find({"doNotUse": {"$exists": False}})
             for row in rows:
-                PROJECT[row['name']] = True
-                PROJECT[row['project']] = True
+                local_project[row['name']] = True
+                local_project[row['project']] = True
         except Exception as err:
             return render_template('warning.html', urlroot=request.url_root,
                                    title=render_warning("Database error"), message=err)
+        CVTERM.update(local_cvterm)
+        PROJECT.update(local_project)
+        DB['dis'] = dis_db
     app.config["START_TIME"] = time()
     app.config["COUNTER"] += 1
     endpoint = request.endpoint if request.endpoint else "(Unknown)"


### PR DESCRIPTION
Summary

 Two changes on graphs:

 1. Clickable bar charts → drill-down reports (553aad5) — Bokeh bar charts were inert (hover only). All three producers in dis_plots.py (stacked_bar_chart, dual_axis_chart, hbar_chart) take an optional nav arg; a shared _make_clickable() helper wires a TapTool + CustomJS. A bar follows a URL (GET) or submits a hidden form to /doiui/custom (POST-only). Each drill carries the page's scope so the landing count matches the bar.
 - New navigation: citation_metrics, dois_oa, dois_preprint_year (year → publishing_year); figshare_stats & zenodo_stats (year → /<repo>_stats/<year>); subscription/year (provider → /subscription/cost/<provider>).
 - Mirror existing table drill-downs: dois_time, org_year, subscription/cost (year); figshare_groups & zenodo_groups (group → ?stem=/?concept=, full untruncated stem carried).
 - v1 stacked tap drills by bar/year (segment-level deferred). Deferred for lack of a faithful single-field target: dois_top, figshare/zenodo resource-type bars, acknowledgement_stats. Bumps __version__ to 119.24.0.

 2. Atomic before_request init (7e16b63) — a transient cvterm/project_map load failure left DB['dis'] set, so init was never retried and the app ran with an empty CVTERM, 500ing CVTERM-dependent pages until restart. Now globals commit only after all reads succeed.

Testing: compiles, no regressions; drill destinations resolve; verified end-to-end in a real browser (Playwright + system Chrome) — bar clicks on /dois_oa, /figshare_groups, /subscription/cost land on the correct pages.

 🤖 Generated with Claude Code
 
 @stuarteberg