### PR TITLE
feat(email_authors): enrich DIS staff summary email and harden sends

### DIFF
--- a/sync/bin/email_authors.py
+++ b/sync/bin/email_authors.py
@@ -2,7 +2,7 @@
     Email information on newly-added DOIs to authors
 '''
 
-__version__ = '1.3.0'
+__version__ = '1.7.0'
 
 import argparse
 from datetime import datetime, timedelta
@@ -20,6 +20,28 @@ DB = {}
 # DOI-level data
 AUTHORLIST = {}
 TAGLIST = {}
+# Per-run caches for external lookups, keyed by employeeId
+PEOPLE_CACHE = {}
+ORCID_CACHE = {}
+# doi_common author-detail match type -> display label/color for the staff email
+MATCH_LABEL = {'asserted': 'Affiliation', 'ORCID': 'ORCID', 'name': 'Name'}
+MATCH_COLOR = {'asserted': 'limegreen', 'ORCID': 'limegreen', 'name': 'crimson'}
+# Inline CSS for the staff-email author match table
+TH_L = "style='text-align:left; padding:4px 8px; border-bottom:2px solid #888;'"
+TH_C = "style='text-align:center; padding:4px 8px; border-bottom:2px solid #888;'"
+TD_L = "style='padding:4px 8px; border-bottom:1px solid #ddd; vertical-align:top;'"
+TD_C = "style='padding:4px 8px; border-bottom:1px solid #ddd; vertical-align:top; " \
+       "text-align:center;'"
+BADGE_RED = "background-color:#c0392b; color:#fff; padding:2px 8px; " \
+            "border-radius:10px; font-size:12px; white-space:nowrap;"
+BADGE_ORANGE = "background-color:orange; color:#fff; padding:2px 8px; " \
+               "border-radius:10px; font-size:12px; white-space:nowrap;"
+# Subject line for the DIS staff summary email
+STAFF_SUBJECT = "Emails have been sent to authors for recent publications"
+# F/L author-role circle badge for the staff-email author table
+AUTHOR_CIRCLE = "display:inline-block; width:16px; height:16px; line-height:16px; " \
+                "border-radius:50%; background-color:#5b9bd5; color:#fff; " \
+                "text-align:center; font-size:11px; font-weight:bold; margin-left:4px;"
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -66,7 +88,56 @@ def get_citation(row):
 
     authors = DL.get_author_list(row)
     title = DL.get_title(row)
-    return f"{authors} {title}. https://doi.org/{row['doi']}."
+    citation = f"{authors} {title}."
+    year = str(row['jrc_publishing_date'])[:4] if row.get('jrc_publishing_date') else ''
+    meta = ", ".join(filter(None, [row.get('jrc_journal'), year]))
+    if meta:
+        citation += f" {meta}."
+    return citation + f" https://doi.org/{row['doi']}."
+
+
+def doi_type_display(row):
+    ''' Build a human-readable type/subtype string for a DOI
+        Keyword arguments:
+          row: row from the dois collection
+        Returns:
+          "type / subtype" style string, or "" if no type is present
+    '''
+    parts = []
+    if row.get('jrc_obtained_from') == 'DataCite':
+        types = row.get('types', {})
+        general = types.get('resourceTypeGeneral')
+        specific = types.get('resourceType')
+        if general:
+            parts.append(general)
+        if specific and specific != general:
+            parts.append(specific)
+    else:
+        # Crossref
+        if row.get('type'):
+            parts.append(row['type'])
+        if row.get('subtype'):
+            parts.append(row['subtype'])
+    return " / ".join(parts)
+
+
+def related_publication(row):
+    ''' Preprint/published counterpart DOIs for a row, from jrc_preprint
+        Keyword arguments:
+          row: row from the dois collection
+        Returns:
+          Tuple (label, [dois]) for the related work, or None. label is
+          "Published version" when this row is itself a preprint, else "Preprint".
+    '''
+    related = row.get('jrc_preprint')
+    if not related:
+        return None
+    dois = related if isinstance(related, list) else [related]
+    dois = [doi for doi in dois if doi]
+    if not dois:
+        return None
+    label = "Published version" if DL.is_preprint(row) else "Preprint"
+    return label, dois
 
 
 def create_doilists(row):
@@ -85,24 +156,48 @@ def create_doilists(row):
         return
     names = []
     for auth in row['jrc_author']:
-        author_valid = valid_author(auth)
-        if not author_valid:
+        valid, _orcid = valid_author(auth)
+        if not valid:
             continue
-        try:
-            resp = JRC.call_people_by_id(auth)
-        except Exception as err:
-            print(type(err).__name__)
-            LOGGER.warning(f"Error calling people by ID: {err}")
-            terminate_program(err)
+        resp = people_by_id(auth)
         if not resp or 'employeeId' not in resp or not resp['employeeId']:
             LOGGER.error(f"No People information found for {auth}")
             continue
-        try:
-            names.append(' '.join([resp['nameFirstPreferred'], resp['nameLastPreferred']]))
-        except Exception as err:
-            LOGGER.warning(f"Error getting author name: {err}")
-            terminate_program(err)
+        first = resp.get('nameFirstPreferred')
+        last = resp.get('nameLastPreferred')
+        if first and last:
+            names.append(' '.join([first, last]))
+        else:
+            LOGGER.warning(f"No preferred name found for {auth}")
     AUTHORLIST[row['doi']] = ", ".join(names)
+
+
+def orcid_record(authid):
+    ''' Cached lookup of an employee's record in the orcid collection
+        Keyword arguments:
+          authid: employeeId
+        Returns:
+          The orcid-collection record, or None if there is none
+    '''
+    if authid not in ORCID_CACHE:
+        ORCID_CACHE[authid] = DL.single_orcid_lookup(authid, DB['dis'].orcid, 'employeeId')
+    return ORCID_CACHE[authid]
+
+
+def people_by_id(authid):
+    ''' Cached lookup of an employee's People record
+        Keyword arguments:
+          authid: employeeId
+        Returns:
+          The People record, or None if unavailable (errors are logged once)
+    '''
+    if authid not in PEOPLE_CACHE:
+        try:
+            PEOPLE_CACHE[authid] = JRC.call_people_by_id(authid)
+        except Exception as err:
+            LOGGER.error(f"Error calling People by ID for {authid}: {err}")
+            PEOPLE_CACHE[authid] = None
+    return PEOPLE_CACHE[authid]
 
 
 def valid_author(authid):
@@ -110,12 +205,13 @@ def valid_author(authid):
         Keyword arguments:
           authid: author ID
         Returns:
-          True if valid, False otherwise
+          Tuple of (is_valid, orcid). is_valid is False for unknown or alumni
+          authors; orcid is the author's ORCID, or None if they have none.
     '''
-    orc = DL.single_orcid_lookup(authid, DB['dis'].orcid, 'employeeId')
+    orc = orcid_record(authid)
     if not orc or 'alumni' in orc:
-        return False
-    return orc['orcid'] if 'orcid' in orc else True
+        return False, None
+    return True, orc.get('orcid') or None
 
 
 def update_processing(doi):
@@ -136,51 +232,241 @@ def update_processing(doi):
         terminate_program(err)
 
 
-def process_authors(authors, publications, cnt):
-    ''' Create and send emails to each author with their resources
+def matched_authors(row):
+    ''' Get the Janelia-matched authors for a DOI, with match details
         Keyword arguments:
-          authors: dictionary of authors and their citations
-          publications: list of citations
-          cnt: DOI count
+          row: row from the dois collection
         Returns:
-          None
+          List of author detail dicts whose match type is affiliation, ORCID,
+          or name (i.e. 'match' is set). Each dict is tagged with 'name_green':
+          True only when the author's employeeId is in the DOI's jrc_author
+          list. Empty list on error or no matches.
     '''
-    notified = []
-    # Individual author emails
-    summary = ""
-    alumni = []
-    for auth, val in authors.items():
-        missing_orcid = False
-        author_valid = valid_author(auth)
-        if not author_valid:
-            LOGGER.warning(f"Skipping alumnus {auth}")
-            arec = DL.single_orcid_lookup(auth, DB['dis'].orcid, 'employeeId')
+    try:
+        details = DL.get_author_details(row, DB['dis'].orcid)
+    except Exception as err:
+        LOGGER.error(f"Could not get author details for {row['doi']}: {err}")
+        return []
+    jrc_authors = set(row.get('jrc_author', []))
+    matched = []
+    for auth in details or []:
+        if not auth.get('match'):
+            continue
+        auth['name_green'] = bool(auth.get('employeeId')) \
+                             and auth['employeeId'] in jrc_authors
+        matched.append(auth)
+    return matched
+
+
+def author_match_table(authors):
+    ''' Build an HTML table of matched Janelia authors for a publication
+        Keyword arguments:
+          authors: list of author detail dicts (from matched_authors)
+        Returns:
+          HTML string (a <table>, or a short note if there are no matches)
+    '''
+    rows_html = ""
+    for auth in authors:
+        name = auth.get('name') \
+               or ' '.join([auth.get('given', ''), auth.get('family', '')]).strip()
+        if auth.get('name_green'):
+            name = f"<span style='color:forestgreen;'>{name}</span>"
+        if auth.get('is_first'):
+            name += f"<span style='{AUTHOR_CIRCLE}'>F</span>"
+        if auth.get('is_last'):
+            name += f"<span style='{AUTHOR_CIRCLE}'>L</span>"
+        orcid = auth.get('orcid')
+        orcid_cell = f"<a href='https://dis.int.janelia.org/orcidui/{orcid}'>{orcid}</a>" \
+                     if orcid else ""
+        match_type = auth.get('match')
+        label = MATCH_LABEL.get(match_type, match_type or "")
+        color = MATCH_COLOR.get(match_type)
+        match_cell = f"<span style='color:{color};'>{label}</span>" if color else label
+        worker_type = auth.get('workerType')
+        if auth.get('alumni'):
+            status_cell = f"<span style='{BADGE_RED}'>Former employee</span>"
+        elif not auth.get('in_database'):
+            status_cell = f"<span style='{BADGE_RED}'>Not in database</span>"
+        elif worker_type and worker_type != 'Employee':
+            status_cell = f"<span style='{BADGE_ORANGE}'>{worker_type}</span>"
+        else:
+            status_cell = "<span style='color:forestgreen; font-size:18px;'>&#10004;</span>"
+        notes = auth.get('match_notes', "")
+        rows_html += f"<tr><td {TD_L}>{name}</td>" \
+                     + f"<td {TD_L}>{orcid_cell}</td>" \
+                     + f"<td {TD_C}>{match_cell}</td>" \
+                     + f"<td {TD_C}>{status_cell}</td>" \
+                     + f"<td {TD_L}>{notes}</td></tr>"
+    if not rows_html:
+        return "<p style='margin:4px 0 0 0; color:#888;'><em>No matched Janelia authors.</em></p>"
+    return "<table style='border-collapse:collapse; margin:8px 0 0 0; font-size:14px;'>" \
+           + f"<tr><th {TH_L}>Author</th><th {TH_L}>ORCID</th>" \
+           + f"<th {TH_C}>Match type</th><th {TH_C}>Current employee</th>" \
+           + f"<th {TH_L}>Match notes</th></tr>" \
+           + rows_html + "</table>"
+
+
+def legend_section():
+    ''' Build the "how to read this email" legend for the staff summary
+        Returns:
+          HTML string
+    '''
+    circle_f = f"<span style='{AUTHOR_CIRCLE}'>F</span>"
+    circle_l = f"<span style='{AUTHOR_CIRCLE}'>L</span>"
+    check = "<span style='color:forestgreen; font-size:16px;'>&#10004;</span>"
+    items = [
+        "<span style='color:forestgreen; font-weight:bold;'>Green author name</span>"
+        " &ndash; the author's employee ID is on this paper's Janelia author list.",
+        f"{circle_f} / {circle_l} &ndash; first / last author of the paper.",
+        "<strong>Match type</strong> &ndash; how the author was matched: "
+        f"<span style='color:{MATCH_COLOR['asserted']};'>Affiliation</span>, "
+        f"<span style='color:{MATCH_COLOR['ORCID']};'>ORCID</span>, or "
+        f"<span style='color:{MATCH_COLOR['name']};'>Name</span>.",
+        f"<strong>Current employee</strong> &ndash; {check} current employee; "
+        f"<span style='{BADGE_ORANGE}'>worker type</span> non-standard worker type; "
+        f"<span style='{BADGE_RED}'>Former employee</span> or "
+        f"<span style='{BADGE_RED}'>Not in database</span>.",
+    ]
+    lis = "".join(f"<li style='margin:2px 0;'>{item}</li>" for item in items)
+    box = "background-color:#f5f5f5; border:1px solid #ddd; border-radius:6px; " \
+          "padding:10px 14px; margin:8px 0; font-size:13px;"
+    return f"<div style='{box}'><strong>How to read this email:</strong>" \
+           + f"<ul style='margin:6px 0 0 0; padding-left:20px;'>{lis}</ul></div>"
+
+
+def pub_section(pub):
+    ''' Build the HTML block for one publication in the staff summary
+        Keyword arguments:
+          pub: staff-summary publication dict
+        Returns:
+          HTML string
+    '''
+    doi = pub['doi']
+    doi_link = f"<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a>"
+    meta = f"<strong>DOI:</strong> {doi_link}"
+    for label, key in (('Source', 'source'), ('Type', 'doi_type'),
+                       ('Published', 'published'), ('Added', 'inserted')):
+        if pub.get(key):
+            meta += f" &nbsp;|&nbsp; <strong>{label}:</strong> {pub[key]}"
+    if pub.get('total_count'):
+        meta += " &nbsp;|&nbsp; <strong>Janelia authors:</strong> " \
+                + f"{pub['jan_count']} of {pub['total_count']}"
+    html = "<div style='margin-bottom:40px;'>"
+    html += f"<p style='margin:0 0 4px 0; font-size:14px;'>{meta}</p>"
+    html += f"<p style='margin:0 0 4px 0;'>{pub['citation']}</p>"
+    if pub.get('related'):
+        rlabel, rdois = pub['related']
+        links = ", ".join(f"<a href='https://dis.int.janelia.org/doiui/{d}'>{d}</a>"
+                          for d in rdois)
+        html += "<p style='margin:0 0 4px 0; font-size:14px;'>" \
+                + f"<strong>{rlabel}:</strong> {links}</p>"
+    if pub.get('tags'):
+        tag_style = "background-color:#4b0082; color:#fff; padding:2px 8px; " \
+                    "border-radius:10px; font-size:12px; white-space:nowrap; " \
+                    "display:inline-block; margin:0 4px 4px 0;"
+        badges = "".join(f"<span style='{tag_style}'>{tag}</span>"
+                         for tag in pub['tags'].split(", "))
+        html += "<p style='margin:0;'><span style='font-weight:bold;'>Tags:</span> " \
+                + badges + "</p>"
+    html += author_match_table(pub['authors'])
+    return html + "</div>"
+
+
+def skipped_section(skipped):
+    ''' Build the HTML block listing authors who were not notified
+        Keyword arguments:
+          skipped: list of {'skip', 'label'} dicts
+        Returns:
+          HTML string
+    '''
+    items = "".join(f"<li>{item['label']} &ndash; {item['skip']}</li>"
+                    for item in skipped)
+    return "<hr style='border:none; border-top:1px solid #ccc; margin:16px 0;'>" \
+           + "<p style='margin:0 0 4px 0;'><strong>Authors not notified:</strong></p>" \
+           + f"<ul style='margin:0;'>{items}</ul>"
+
+
+def build_staff_email(staff_pubs, cnt, num_authors, skipped):
+    ''' Build the HTML body for the DIS staff summary email
+        Keyword arguments:
+          staff_pubs: list of {doi, citation, source, doi_type, published, tags,
+                      authors} dicts
+          cnt: DOI count
+          num_authors: number of authors emailed
+          skipped: list of {'skip', 'label'} dicts for authors not notified
+        Returns:
+          HTML string
+    '''
+    html = "<div style='font-family:Arial,Helvetica,sans-serif; color:#222;'>"
+    html += f"<p>{STAFF_SUBJECT}.</p>"
+    summary = "<p><strong>DOIs:</strong> " + f"{cnt}" \
+              + " &nbsp;|&nbsp; <strong>Authors:</strong> " + f"{num_authors}"
+    if skipped:
+        summary += " &nbsp;|&nbsp; <strong>Not notified:</strong> " + f"{len(skipped)}"
+    summary += " &nbsp;|&nbsp; <strong>Window:</strong> last " \
+               + f"{ARG.DAYS} day{'' if ARG.DAYS == 1 else 's'}</p>"
+    html += summary
+    html += legend_section()
+    html += "<hr style='border:none; border-top:1px solid #ccc; margin:16px 0;'>"
+    for pub in staff_pubs:
+        html += pub_section(pub)
+    if skipped:
+        html += skipped_section(skipped)
+    return html + "</div>"
+
+
+def resolve_author(auth):
+    ''' Resolve a Janelia author to their notification details
+        Keyword arguments:
+          auth: author employeeId
+        Returns:
+          On success, a dict with 'first', 'name', 'email', and 'orcid'. When
+          the author cannot be notified, a dict with 'skip' (the reason) and
+          'label' (name or ID); the reason is also logged.
+    '''
+    valid, orcid = valid_author(auth)
+    if not valid:
+        arec = orcid_record(auth)
+        if arec and arec.get('given') and arec.get('family'):
             name = ' '.join([arec['given'][0], arec['family'][0]])
-            alumni.append(name)
-            continue
-        resp = JRC.call_people_by_id(auth)
-        if not resp or 'employeeId' not in resp or not resp['employeeId']:
-            LOGGER.warning(f"No People information found for {auth}")
-            continue
-        name = ' '.join([resp['nameFirstPreferred'], resp['nameLastPreferred']])
-        if not resp.get('email'):
-            LOGGER.warning(f"No email found for {name}")
-            continue
-        email = DISCONFIG['developer'] if ARG.TEST else resp['email']
-        subject = "Your recent publication" if len(val['citations']) == 1 \
-                  else "Your recent publications"
-        text1 = "publication" if len(val['citations']) == 1 else "publications"
-        text = f'''\
-Hello {resp['nameFirstPreferred']},<br><br>
+            LOGGER.warning(f"Skipping alumnus {name} ({auth})")
+            return {'skip': 'Former employee', 'label': name}
+        LOGGER.warning(f"Skipping unknown author {auth}")
+        return {'skip': 'Unknown author', 'label': auth}
+    resp = people_by_id(auth)
+    if not resp or 'employeeId' not in resp or not resp['employeeId']:
+        LOGGER.warning(f"No People information found for {auth}")
+        return {'skip': 'No People record', 'label': auth}
+    first = resp.get('nameFirstPreferred')
+    last = resp.get('nameLastPreferred')
+    if not (first and last):
+        LOGGER.warning(f"No preferred name found for {auth}")
+        return {'skip': 'No preferred name', 'label': auth}
+    name = ' '.join([first, last])
+    if not resp.get('email'):
+        LOGGER.warning(f"No email found for {name}")
+        return {'skip': 'No email address', 'label': name}
+    return {'first': first, 'name': name, 'email': resp['email'], 'orcid': orcid}
+
+
+def author_email_body(info, val):
+    ''' Build the HTML body of one author's DOI-notification email
+        Keyword arguments:
+          info: author dict from resolve_author (first, name, email, orcid)
+          val: {'citations': [...], 'dois': [...]} for this author
+        Returns:
+          HTML string
+    '''
+    first = info['first']
+    text1 = "publication" if len(val['citations']) == 1 else "publications"
+    text = f'''\
+Hello {first},<br><br>
 Janelia’s Data and Information Services department (DIS) has added your recent
 {text1} (DOIs listed below) to our database:<br>
         '''
-        for doi in val['dois']:
-            text += f"<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
-            if doi not in notified and ARG.WRITE:
-                notified.append(doi)
-                update_processing(doi)
-        text += '''\
+    for doi in val['dois']:
+        text += f"<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
+    text += '''\
 <br><br>
 To ensure accuracy, review the metadata below and
 <em>let us know if they are incorrect by responding to this email</em>.
@@ -198,46 +484,120 @@ The Janelia author names listed below may not perfectly correspond to author nam
 not affiliated with Janelia, please let us know.
 <br><br>
         '''
-        if isinstance(author_valid, bool):
-            LOGGER.warning(f"Author {name} has no ORCID")
-            missing_orcid = True
-            text += "<strong>Note:</strong> We could not find " \
-                    + "an ORCID for you. We ask that you please create one with " \
-                    + "your Janelia affiliation. To create one, please visit " \
-                    + "<a href='https://orcid.org/register'>ORCID</a>.<br><br>"
-        text += "Thank you and have a great day,<br><br>Lauren Acquarole<br>Mary Lay<br><br>"
-        text += "<h3>Citations</h3>"
-        for res in val['citations']:
-            text += f"{res}"
-            doi = val['dois'].pop(0)
-            if doi in TAGLIST:
-                text += f"<br><span style='font-weight: bold'>Tags:</span> {TAGLIST[doi]}"
-            if doi in AUTHORLIST:
-                text += "<br><span style='font-weight: bold'>Janelia authors:</span> " \
-                        + f"{AUTHORLIST[doi]}"
-            text += "<br><br>"
-        summary += f"{name} has {len(val['citations'])} " \
-                   + f"citation{'' if len(val['citations']) == 1 else 's'}"
-        if missing_orcid:
-            summary += " (missing ORCID)"
-        summary += "<br>"
-        if ARG.WRITE or ARG.TEST:
+    if not info['orcid']:
+        LOGGER.warning(f"Author {info['name']} has no ORCID")
+        text += "<strong>Note:</strong> We could not find " \
+                + "an ORCID for you. We ask that you please create one with " \
+                + "your Janelia affiliation. To create one, please visit " \
+                + "<a href='https://orcid.org/register'>ORCID</a>.<br><br>"
+    text += "Thank you and have a great day,<br><br>Lauren Acquarole<br>Mary Lay<br><br>"
+    text += "<h3>Citations</h3>"
+    for res, doi in zip(val['citations'], val['dois']):
+        text += f"{res}"
+        if doi in TAGLIST:
+            text += f"<br><span style='font-weight: bold'>Tags:</span> {TAGLIST[doi]}"
+        if doi in AUTHORLIST:
+            text += "<br><span style='font-weight: bold'>Janelia authors:</span> " \
+                    + f"{AUTHORLIST[doi]}"
+        text += "<br><br>"
+    return text
+
+
+def send_staff_summary(cnt, staff_pubs, num_authors, skipped):
+    ''' Send the DIS staff summary email (write and test modes only)
+        Keyword arguments:
+          cnt: DOI count
+          staff_pubs: list of {doi, citation, source, doi_type, published, tags,
+                      authors} dicts for the summary
+          num_authors: number of authors emailed
+          skipped: list of {'skip', 'label'} dicts for authors not notified
+        Returns:
+          None
+    '''
+    if not (ARG.WRITE or ARG.TEST) or not cnt:
+        return
+    body = build_staff_email(staff_pubs, cnt, num_authors, skipped)
+    email = [DISCONFIG['developer']] if ARG.TEST else DISCONFIG['receivers']
+    try:
+        JRC.send_email(body, DISCONFIG['sender'], email, STAFF_SUBJECT, mime='html')
+    except Exception as err:
+        LOGGER.error(f"Failed to send DIS staff summary email: {err}")
+        return
+    LOGGER.info(f"DIS staff summary email sent to {', '.join(email)}")
+
+
+def send_one_email(info, subject, text, example_sent):
+    ''' Send (or, per run mode, simulate) one author's notification email
+        Keyword arguments:
+          info: resolved author dict (name, email, ...)
+          subject: email subject
+          text: HTML email body
+          example_sent: whether a test-mode example has already been sent
+        Returns:
+          Tuple (delivered, example_sent). delivered is True only when a real
+          email was sent to the author (write mode); example_sent is the
+          possibly-updated flag.
+    '''
+    name = info['name']
+    email = DISCONFIG['developer'] if ARG.TEST else info['email']
+    if ARG.WRITE:
+        try:
             JRC.send_email(text, DISCONFIG['sender'], [email], subject, mime='html')
+        except Exception as err:
+            LOGGER.error(f"Failed to send email to {name} ({email}): {err}")
+            return False, example_sent
         LOGGER.info(f"Email sent to {name} ({email})")
-    if not (ARG.WRITE or ARG.TEST):
-        return
-    # Summary email
-    if not cnt:
-        return
-    subject = "Emails have been sent to authors for recent publications"
-    text = f"{subject}.<br>DOIs: {cnt}<br>Authors: {len(authors)}<br><br>"
-    text += "<br><br>".join(publications)
-    text += "<br><br>" + summary
-    if alumni:
-        text += "<br>Alumni authors:<br>"
-        text += "<br>".join(alumni)
-    email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
-    JRC.send_email(text, DISCONFIG['sender'], email, subject, mime='html')
+        return True, example_sent
+    if ARG.TEST:
+        if example_sent:
+            LOGGER.info(f"Skipping individual email for {name} " \
+                        + "(test mode example already sent)")
+            return False, example_sent
+        try:
+            JRC.send_email(text, DISCONFIG['sender'], [email], subject, mime='html')
+        except Exception as err:
+            LOGGER.error(f"Failed to send example email to {email}: {err}")
+            return False, example_sent
+        LOGGER.info(f"Example author email sent to developer ({email}) for {name}")
+        return False, True
+    LOGGER.info(f"Would send email to {name} ({email})")
+    return False, example_sent
+
+
+def process_authors(authors, cnt, staff_pubs):
+    ''' Create and send emails to each author with their resources
+        Keyword arguments:
+          authors: dictionary of authors and their citations
+          cnt: DOI count
+          staff_pubs: list of {doi, citation, source, doi_type, published, tags,
+                      authors} dicts for the DIS staff summary email
+        Returns:
+          None
+    '''
+    notified = []
+    skipped = []
+    emailed = 0
+    # Individual author emails. In test mode we send a single example to the
+    # developer rather than one email per author.
+    example_sent = False
+    for auth, val in authors.items():
+        info = resolve_author(auth)
+        if info.get('skip'):
+            skipped.append(info)
+            continue
+        subject = "Your recent publication" if len(val['citations']) == 1 \
+                  else "Your recent publications"
+        text = author_email_body(info, val)
+        delivered, example_sent = send_one_email(info, subject, text, example_sent)
+        if ARG.WRITE and not delivered:
+            continue
+        emailed += 1
+        if ARG.WRITE:
+            for doi in val['dois']:
+                if doi not in notified:
+                    notified.append(doi)
+                    update_processing(doi)
+    send_staff_summary(cnt, staff_pubs, emailed, skipped)
 
 
 def process_dois():
@@ -261,10 +621,9 @@ def process_dois():
         terminate_program(err)
     LOGGER.info(f"DOIs found: {cnt}")
     authors = {}
-    publications = []
+    staff_pubs = []
     for row in rows:
         citation = get_citation(row)
-        publications.append(citation)
         for auth in row['jrc_author']:
             if auth not in authors:
                 authors[auth] = {"citations": [], "dois": []}
@@ -272,8 +631,18 @@ def process_dois():
             authors[auth]['dois'].append(row['doi'])
         if row['doi'] not in AUTHORLIST:
             create_doilists(row)
+        staff_pubs.append({'doi': row['doi'], 'citation': citation,
+                           'source': row.get('jrc_obtained_from', ''),
+                           'doi_type': doi_type_display(row),
+                           'published': row.get('jrc_publishing_date', ''),
+                           'inserted': str(row.get('jrc_inserted', '')).split(' ', maxsplit=1)[0],
+                           'jan_count': len(row.get('jrc_author', [])),
+                           'total_count': len(row.get('author') or row.get('creators') or []),
+                           'related': related_publication(row),
+                           'tags': TAGLIST.get(row['doi']),
+                           'authors': matched_authors(row)})
     LOGGER.info(f"Authors found: {len(authors)}")
-    process_authors(authors, publications, cnt)
+    process_authors(authors, cnt, staff_pubs)
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Staff summary email additions:
- Per-publication header: DOI (linked), Source, Type, Published, Added (jrc_inserted), and Janelia-vs-total author count
- Citations now include journal (jrc_journal) and year (jrc_publishing_date)
- Preprint/published counterpart line from jrc_preprint
- First/last Janelia authors flagged with F/L circle badges (is_first/is_last)
- Orange badge for non-"Employee" workerType in the Current employee column
- "How to read this email" legend and an "Authors not notified" list
- Accurate emailed-author count (was len(authors), which over-counted skips)

Fix: green author name now requires the employeeId to be in the DOI's jrc_author list (previously any affiliation/ORCID match turned it green).

Reliability/perf: cache People and ORCID lookups per run; wrap all send_email calls so one failure no longer aborts the batch.

Refactor: decompose process_authors/build_staff_email into focused helpers; hoist inline CSS to module constants. pylint 10.00/10.

@stuarteberg