### PR TITLE
feat(licenses): extract shared license-resolution module, harden network handling

### DIFF
--- a/sync/bin/dis_license_lib.py
+++ b/sync/bin/dis_license_lib.py
@@ -1,0 +1,288 @@
+""" dis_license_lib.py
+    Shared license-resolution helpers for DOI records -- not a standalone program.
+    Used by sync_datacite_legal.py and sync_openalex.py to resolve jrc_license via
+    a waterfall: DataCite rightsList -> OpenAlex -> PMC (efetch) -> Unpaywall.
+"""
+
+from dataclasses import dataclass
+import logging
+import os
+import re
+import time
+import requests
+import xmltodict
+import pyalex
+import doi_common.doi_common as DL
+
+# pylint: disable=broad-exception-caught,logging-fstring-interpolation
+
+LOGGER = logging.getLogger(__name__)
+
+EFETCH_PMC = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pmc&rettype=full"
+CC_LICENSE_RE = re.compile(r'creativecommons\.org/licenses/([a-z-]+)/([0-9.]+)', re.IGNORECASE)
+CC0_RE = re.compile(r'creativecommons\.org/publicdomain/zero/([0-9.]+)', re.IGNORECASE)
+
+_UNSET = object()
+_STATE = {'unpaywall_unreachable': False, 'openalex_unreachable': False,
+          'pmc_unreachable': False}
+
+# pyalex sets no timeout on its requests.Session calls, so a network that can't
+# reach api.openalex.org hangs for the OS-level TCP timeout (minutes) instead of
+# failing fast. Inject a default timeout for any request that doesn't set one.
+_ORIG_SESSION_REQUEST = requests.Session.request
+def _request_with_default_timeout(self, method, url, **kwargs):
+    kwargs.setdefault('timeout', 10)
+    return _ORIG_SESSION_REQUEST(self, method, url, **kwargs)
+requests.Session.request = _request_with_default_timeout
+
+__version__ = '1.3.0'
+
+
+@dataclass
+class LicenseResult:  # pylint: disable=too-many-instance-attributes
+    """ Result of a license resolution attempt """
+    mapped: str = None
+    tier: str = None
+    pmc_skipped_no_id: bool = False
+    pmc_429_exhausted: bool = False
+    pmc_unreachable: bool = False
+    unpaywall_not_indexed: bool = False
+    unpaywall_unreachable: bool = False
+    openalex_unreachable: bool = False
+
+
+def cc_url_to_slug(url):
+    """ Convert a Creative Commons license URL to the slug used in the license map
+        Keyword arguments:
+          url: Creative Commons license URL
+        Returns:
+          Slug (e.g. "cc-by-nc-4.0"), or None if the URL isn't a recognized CC license
+    """
+    if not url:
+        return None
+    match = CC_LICENSE_RE.search(url)
+    if match:
+        return f"cc-{match.group(1).lower()}-{match.group(2)}"
+    match = CC0_RE.search(url)
+    if match:
+        return f"cc0-{match.group(1)}"
+    return None
+
+
+def get_pmc_license(pmcid):  # pylint: disable=too-many-return-statements
+    """ Get the raw license string for a PMCID via NCBI E-utilities (efetch, db=pmc)
+        Keyword arguments:
+          pmcid: PMCID
+        Returns:
+          (license, rate_limited, unreachable) -- license is the raw string or None;
+          rate_limited is True if PMC was still returning 429 after all retries;
+          unreachable is True if PMC couldn't be reached at all (this or an earlier call)
+    """
+    if _STATE['pmc_unreachable']:
+        return None, False, True
+    # efetch (db=pmc) honors NCBI_API_KEY for a 10 req/s limit, unlike the legacy
+    # PMC OAI-PMH endpoint (3 req/s, no key support) this used to call
+    time.sleep(0.11)
+    url = f"{EFETCH_PMC}&id={pmcid}&api_key={os.environ['NCBI_API_KEY']}"
+    data = None
+    for attempt in range(3):
+        try:
+            resp = requests.get(url, timeout=5)
+            if not resp.ok:
+                raise requests.HTTPError(resp.status_code, resp.text)
+            data = xmltodict.parse(resp.text)
+            break
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as err:
+            LOGGER.warning(f"PMC unreachable, skipping it for the rest of this run: {err}")
+            _STATE['pmc_unreachable'] = True
+            return None, False, True
+        except Exception as err:
+            if '429' in str(err) and attempt < 2:
+                wait = 60 * (attempt + 1)
+                LOGGER.warning(f"PMC 429 for {pmcid}, retrying in {wait}s (attempt {attempt+1})")
+                time.sleep(wait)
+            elif '429' in str(err):
+                LOGGER.warning(f"PMC 429 for {pmcid} after 3 attempts, skipping")
+                return None, True, False
+            else:
+                raise
+    if not data:
+        return None, False, False
+    try:
+        permissions = data['pmc-articleset']['article']['front']['article-meta']['permissions']
+        license_url = permissions['license']['ali:license_ref']['#text']
+    except (KeyError, TypeError):
+        return None, False, False
+    return cc_url_to_slug(license_url) or license_url, False, False
+
+
+def get_unpaywall_license(doi):  # pylint: disable=too-many-return-statements
+    """ Get the raw license string for a DOI from Unpaywall
+        Keyword arguments:
+          doi: DOI
+        Returns:
+          (license, not_indexed, unreachable) -- license is the raw string or None;
+          not_indexed is True if Unpaywall has no record for this DOI; unreachable
+          is True if Unpaywall couldn't be reached at all (this or an earlier call)
+    """
+    if _STATE['unpaywall_unreachable']:
+        return None, False, True
+    try:
+        data = DL.get_doi_record(doi, source='unpaywall')
+    except ValueError:
+        # Unpaywall 404s with an HTML (non-JSON) body for DOIs it doesn't index
+        # (e.g. datasets/software) -- expected for most DataCite DOIs, not an error
+        return None, True, False
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as err:
+        LOGGER.warning(f"Unpaywall unreachable, skipping it for the rest of this run: {err}")
+        _STATE['unpaywall_unreachable'] = True
+        return None, False, True
+    except Exception as err:
+        LOGGER.warning(f"Could not get Unpaywall license for {doi}: {err}")
+        return None, False, False
+    if not data:
+        return None, False, False
+    best = data.get('best_oa_location') or {}
+    if best.get('license'):
+        return best['license'], False, False
+    for loc in data.get('oa_locations', []):
+        if loc.get('license'):
+            return loc['license'], False, False
+    return None, False, False
+
+
+def get_openalex_record(doi):
+    """ Get the OpenAlex work record for a DOI, with a circuit breaker for
+        connection-level failures. doi_common's own OpenAlex handling already
+        swallows all exceptions (including connection failures) and returns None,
+        so it can't distinguish "not found" from "unreachable" -- call pyalex
+        directly here so we can tell the difference.
+        Keyword arguments:
+          doi: DOI
+        Returns:
+          (data, unreachable) -- data is the OpenAlex work record or None;
+          unreachable is True if OpenAlex couldn't be reached at all
+    """
+    if _STATE['openalex_unreachable']:
+        return None, True
+    try:
+        results = pyalex.Works().filter(doi=doi).get()
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as err:
+        LOGGER.warning(f"OpenAlex unreachable, skipping it for the rest of this run: {err}")
+        _STATE['openalex_unreachable'] = True
+        return None, True
+    except Exception as err:
+        LOGGER.warning(f"OpenAlex unavailable for {doi}: {err}")
+        return None, False
+    if not results:
+        return None, False
+    return results[0], False
+
+
+def license_from_rights_list(row, licmap):
+    """ Try to resolve a license from a DataCite rightsList
+        Keyword arguments:
+          row: DOI record
+          licmap: license map dictionary
+        Returns:
+          Mapped license, or None
+    """
+    if not (row.get('jrc_obtained_from') == 'DataCite' and row.get('rightsList')):
+        return None
+    licmap_norm = {key.strip().lower(): val for key, val in licmap.items()}
+    for right in row['rightsList']:
+        if 'rightsIdentifier' in right and right['rightsIdentifier'] in licmap:
+            return licmap[right['rightsIdentifier']]
+        if right.get('rights'):
+            if right['rights'] in licmap:
+                return licmap[right['rights']]
+            if right['rights'].strip().lower() in licmap_norm:
+                return licmap_norm[right['rights'].strip().lower()]
+        if 'rightsUri' in right and right['rightsUri'] in licmap:
+            return licmap[right['rightsUri']]
+        if 'rightsIdentifier' in right:
+            LOGGER.error(f"Unknown license (rightsIdentifier) {right['rightsIdentifier']} "
+                         f"for {row['doi']}")
+        elif right.get('rights'):
+            LOGGER.error(f"Unknown license (rights) {right['rights']} for {row['doi']}")
+        elif 'rightsUri' in right:
+            LOGGER.error(f"Unknown license (rightsUri) {right['rightsUri']} for {row['doi']}")
+        else:
+            LOGGER.error(f"Incorrect rights format {right} for {row['doi']}")
+    return None
+
+
+def license_from_openalex(openalex_data, licmap, doi=None):
+    """ Try to resolve a license from an already-fetched OpenAlex record
+        Keyword arguments:
+          openalex_data: OpenAlex work record (as returned by doi_common), or None
+          licmap: license map dictionary
+          doi: DOI, for logging an unmapped license value
+        Returns:
+          Mapped license, or None
+    """
+    if not openalex_data:
+        return None
+    lic = (openalex_data.get('primary_location') or {}).get('license')
+    if not lic or lic == "False":
+        return None
+    if lic in licmap:
+        return licmap[lic]
+    LOGGER.warning(f"Unknown OpenAlex license {lic} for {doi}")
+    return None
+
+
+def resolve_license(row, licmap, openalex_data=_UNSET):
+    # pylint: disable=too-many-return-statements,too-many-branches
+    """ Resolve a license for a DOI record via the full waterfall:
+        DataCite rightsList -> OpenAlex -> PMC -> Unpaywall
+        Keyword arguments:
+          row: DOI record
+          licmap: license map dictionary
+          openalex_data: pre-fetched OpenAlex record. Pass None if OpenAlex has
+                         already been checked and had nothing; omit entirely to
+                         have this function fetch OpenAlex itself.
+        Returns:
+          LicenseResult
+    """
+    result = LicenseResult()
+    lic = license_from_rights_list(row, licmap)
+    if lic:
+        LOGGER.info(f"Using license (rightsList) {lic} for {row['doi']}")
+        result.mapped = lic
+        result.tier = 'rightsList'
+        return result
+    if openalex_data is _UNSET:
+        time.sleep(.5)
+        openalex_data, openalex_unreachable = get_openalex_record(row['doi'])
+        result.openalex_unreachable = openalex_unreachable
+    lic = license_from_openalex(openalex_data, licmap, doi=row['doi'])
+    if lic:
+        LOGGER.info(f"Using license (OpenAlex) {lic} for {row['doi']}")
+        result.mapped = lic
+        result.tier = 'openalex'
+        return result
+    if row.get('jrc_pmc'):
+        raw, rate_limited, pmc_unreachable = get_pmc_license(row['jrc_pmc'])
+        result.pmc_429_exhausted = rate_limited
+        result.pmc_unreachable = pmc_unreachable
+        if raw:
+            if raw in licmap:
+                result.mapped = licmap[raw]
+                result.tier = 'pmc'
+                LOGGER.info(f"Using license (PMC) {result.mapped} for {row['doi']}")
+                return result
+            LOGGER.warning(f"Unknown PMC license {raw} for {row['doi']}")
+    else:
+        result.pmc_skipped_no_id = True
+    raw, not_indexed, unreachable = get_unpaywall_license(row['doi'])
+    result.unpaywall_not_indexed = not_indexed
+    result.unpaywall_unreachable = unreachable
+    if raw:
+        if raw in licmap:
+            result.mapped = licmap[raw]
+            result.tier = 'unpaywall'
+            LOGGER.info(f"Using license (Unpaywall) {result.mapped} for {row['doi']}")
+            return result
+        LOGGER.warning(f"Unknown Unpaywall license {raw} for {row['doi']}")
+    return result

--- a/sync/bin/sync_datacite_legal.py
+++ b/sync/bin/sync_datacite_legal.py
@@ -1,26 +1,23 @@
-""" sync_figshare_legal.py
-    Sync legal data from Figshare to the database
+""" sync_datacite_legal.py
+    Sync legal (license) data from DataCite to the database
 """
 
 import argparse
 import collections
-import json
 from operator import attrgetter
-import os
 import sys
-import time
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
-import doi_common.doi_common as DL
+import dis_license_lib as DISL
 
-# pylint: disable=broad-exception-caught,logging-fstring-interpolation
+# pylint: disable=broad-exception-caught,logging-fstring-interpolation,duplicate-code
 
 DB = {}
 COUNT = collections.defaultdict(lambda: 0, {})
-ARG = LOGGER = WORK = None
+ARG = LOGGER = None
 LICENSE = {}
 
-__version__ = '1.0.0'
+__version__ = '2.0.0'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -62,76 +59,13 @@ def initialize_program():
         terminate_program(err)
     for row in rows:
         LICENSE[row['name']] = row['display']
-
-
-def get_license(row, licmap):
-    """ Get the license for a DOI
-        Keyword arguments:
-          row: DOI record
-          licmap: license map dictionary
-        Returns:
-          License
-    """
-    if row['jrc_obtained_from'] == 'DataCite':
-        if 'rightsList' in row and row['rightsList']:
-            for right in row['rightsList']:
-                if 'rightsIdentifier' in right and right['rightsIdentifier'] in licmap:
-                    return licmap[right['rightsIdentifier']]
-                elif 'rights' in right and right['rights'] in licmap:
-                    return licmap[right['rights']]
-                elif 'rightsIdentifier' in right:
-                    print(f"Unknown license (rightsIdentifier) {right['rightsIdentifier']} for {row['doi']}")
-                elif 'rights' in right and right['rights']:
-                    print(f"Unknown license (rights) {right['rights']} for {row['doi']}")
-                elif 'rightsUri' in right and right['rightsUri'] in LICENSE:
-                    return licmap[right['rightsUri']]
-                else:
-                    print(f"Incorrect rights format {right} for {row['doi']}")
     try:
-        time.sleep(.5)
-        data = DL.get_doi_record(row['doi'], source='openalex')
+        rows = DB['dis'].cvterm.find({'cv': 'license'})
     except Exception as err:
-        raise err
-    if data:
-        if 'primary_location' in data and data['primary_location'] \
-           and data['primary_location']['license'] and data['primary_location']['license'] != "False":
-            if data['primary_location']['license'] in licmap:
-                return licmap[data['primary_location']['license']]
-    if 'jrc_pmc' not in row or not row['jrc_pmc']:
-        return None
-    time.sleep(0.11)  # stay under NCBI's 10 req/s limit with API key
-    data = None
-    for attempt in range(3):
-        try:
-            data = DL.get_doi_record(row['jrc_pmc'], source='pmc')
-            break
-        except Exception as err:
-            if '429' in str(err) and attempt < 2:
-                wait = 60 * (attempt + 1)
-                LOGGER.warning(f"PMC 429 for {row['jrc_pmc']}, retrying in {wait}s (attempt {attempt+1})")
-                time.sleep(wait)
-            elif '429' in str(err):
-                LOGGER.warning(f"PMC 429 for {row['jrc_pmc']} after 3 attempts, skipping")
-                return None
-            else:
-                raise
-    if not data or 'OAI-PMH' not in data or 'GetRecord' not in data['OAI-PMH'] \
-       or 'record' not in data['OAI-PMH']['GetRecord'] \
-       or 'metadata' not in data['OAI-PMH']['GetRecord']['record'] \
-       or 'article' not in data['OAI-PMH']['GetRecord']['record']['metadata'] \
-       or 'front' not in data['OAI-PMH']['GetRecord']['record']['metadata']['article']:
-        return None
-    front = data['OAI-PMH']['GetRecord']['record']['metadata']['article']['front']
-    if 'article-meta' not in front or 'custom-meta-group' not in front['article-meta'] \
-       or 'custom-meta' not in front['article-meta']['custom-meta-group'] \
-        or not front['article-meta']['custom-meta-group']['custom-meta']:
-        return None
-    for custom_meta in front['article-meta']['custom-meta-group']['custom-meta']:
-        if custom_meta['meta-name'] == 'license':
-            lic = custom_meta['meta-value'].replace(" ", "-").lower()
-            if lic in licmap:
-                return licmap[lic]
-    return None
+        terminate_program(err)
+    for row in rows:
+        if row['name'] not in LICENSE:
+            LICENSE[row['name']] = row['name']
 
 
 def processing():
@@ -149,67 +83,58 @@ def processing():
         terminate_program(err)
     LOGGER.info(f"Found {cnt:,} DOIs to process for DataCite legal data")
     COUNT['read'] = cnt
-    for row in rows:
-        if 'rightsList' in row and row['rightsList']:
-            for right in row['rightsList']:
-                if 'rightsIdentifier' in right and right['rightsIdentifier'] in LICENSE:
-                    row['jrc_license'] = LICENSE[right['rightsIdentifier']]
-                    LOGGER.info(f"Using license (rightsIdentifier) {row['jrc_license']} for {row['doi']}")
-                elif 'rights' in right and right['rights'] in LICENSE:
-                    row['jrc_license'] = LICENSE[right['rights']]
-                    LOGGER.info(f"Using license (rights) {row['jrc_license']} for {row['doi']}")
-                elif 'rightsIdentifier' in right:
-                    LOGGER.error(f"Unknown license (rightsIdentifier) {right['rightsIdentifier']} for {row['doi']}")
-                elif 'rights' in right and right['rights']:
-                    LOGGER.error(f"Unknown license (rights) {right['rights']} for {row['doi']}")
-                elif 'rightsUri' in right and right['rightsUri'] in LICENSE:
-                    row['jrc_license'] = LICENSE[right['rightsUri']]
-                    LOGGER.info(f"Using license (rights) {row['jrc_license']} for {row['doi']}")
-                else:
-                    LOGGER.error(f"Incorrect rights format {right} for {row['doi']}")
-                    continue
-                break
-            if 'jrc_license' in row and row['jrc_license']:
-                COUNT['updated'] += 1
-                if ARG.WRITE:
-                    try:
-                        DB['dis'].dois.update_one({"doi": row['doi']}, {"$set": {"jrc_license": row['jrc_license']}})
-                    except Exception as err:
-                        terminate_program(err)
+    for row in tqdm(rows, desc="Getting license data", total=cnt):
+        result = DISL.resolve_license(row, LICENSE)
+        if result.mapped:
+            row['jrc_license'] = result.mapped
+            COUNT['updated'] += 1
+            if ARG.WRITE:
+                try:
+                    DB['dis'].dois.update_one({"doi": row['doi']},
+                                               {"$set": {"jrc_license": row['jrc_license']}})
+                except Exception as err:
+                    terminate_program(err)
         else:
-            lic = get_license(row, LICENSE)
-            if lic:
-                row['jrc_license'] = lic
-                COUNT['updated'] += 1
-                if ARG.WRITE:
-                    try:
-                        DB['dis'].dois.update_one({"doi": row['doi']}, {"$set": {"jrc_license": row['jrc_license']}})
-                    except Exception as err:
-                        terminate_program(err)
-            else:
-                LOGGER.error(f"No license found for {row['doi']}")
-                COUNT['no_license'] += 1
-    print(f"DOIs read:            {COUNT['read']:,}")
-    print(f"DOIs with no license: {COUNT['no_license']:,}")
-    print(f"DOIs updated:         {COUNT['updated']:,}")
+            LOGGER.error(f"No license found for {row['doi']}")
+            COUNT['no_license'] += 1
+        if result.pmc_skipped_no_id:
+            COUNT['pmc_skipped_no_id'] += 1
+        if result.pmc_429_exhausted:
+            COUNT['pmc_429_exhausted'] += 1
+        if result.pmc_unreachable:
+            COUNT['pmc_unreachable'] += 1
+        if result.unpaywall_not_indexed:
+            COUNT['unpaywall_not_indexed'] += 1
+        if result.unpaywall_unreachable:
+            COUNT['unpaywall_unreachable'] += 1
+        if result.openalex_unreachable:
+            COUNT['openalex_unreachable'] += 1
+    print(f"{'DOIs read:':<32}{COUNT['read']:,}")
+    print(f"{'DOIs with no license:':<32}{COUNT['no_license']:,}")
+    print(f"{'DOIs updated:':<32}{COUNT['updated']:,}")
+    print(f"{'DOIs with no PMC ID:':<32}{COUNT['pmc_skipped_no_id']:,}")
+    print(f"{'DOIs with PMC 429 exhausted:':<32}{COUNT['pmc_429_exhausted']:,}")
+    print(f"{'DOIs skipped (PMC down):':<32}{COUNT['pmc_unreachable']:,}")
+    print(f"{'DOIs not indexed in Unpaywall:':<32}{COUNT['unpaywall_not_indexed']:,}")
+    print(f"{'DOIs skipped (Unpaywall down):':<32}{COUNT['unpaywall_unreachable']:,}")
+    print(f"{'DOIs skipped (OpenAlex down):':<32}{COUNT['openalex_unreachable']:,}")
 
 # -----------------------------------------------------------------------------
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(
-        description="Sync local Workday alumni to orcid")
+        description="Sync legal (license) data from DataCite to the database")
     PARSER.add_argument('--manifold', dest='MANIFOLD', action='store',
                         default='prod', choices=['dev', 'prod'],
                         help='MongoDB manifold (dev, prod)')
     PARSER.add_argument('--write', dest='WRITE', action='store_true',
-                        default=False, help='Actually send emails')
+                        default=False, help='Write to database')
     PARSER.add_argument('--verbose', dest='VERBOSE', action='store_true',
                         default=False, help='Flag, Chatty')
     PARSER.add_argument('--debug', dest='DEBUG', action='store_true',
                         default=False, help='Flag, Very chatty')
     ARG = PARSER.parse_args()
     LOGGER = JRC.setup_logging(ARG)
-    WORK = JRC.simplenamespace_to_dict(JRC.get_config("workday"))
     initialize_program()
     processing()
     terminate_program()

--- a/sync/bin/sync_openalex.py
+++ b/sync/bin/sync_openalex.py
@@ -11,7 +11,7 @@
     jrc_former_status.
 """
 
-__version__ = '3.3.0'
+__version__ = '4.1.0'
 
 import argparse
 import collections
@@ -25,8 +25,9 @@ import traceback
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import dis_license_lib as DISL
 
-# pylint: disable=broad-exception-caught,logging-fstring-interpolation,logging-not-lazy
+# pylint: disable=broad-exception-caught,logging-fstring-interpolation,logging-not-lazy,duplicate-code
 
 ARG = DISCONFIG = LOGGER = None
 DB = {}
@@ -75,6 +76,13 @@ def initialize_program():
     for row in rows:
         LICENSE[row['name']] = row['display']
     try:
+        rows = DB['dis'].cvterm.find({'cv': 'license'})
+    except Exception as err:
+        terminate_program(err)
+    for row in rows:
+        if row['name'] not in LICENSE:
+            LICENSE[row['name']] = row['name']
+    try:
         rows = DB['dis'].subscription.find({"oa_status": {"$exists": True}})
     except Exception as err:
         terminate_program(err)
@@ -103,63 +111,6 @@ def get_dois():
     return dois
 
 
-def get_pmc_license(pmcid):
-    """ Get the license for a PMCID
-        Keyword arguments:
-          pmcid: PMCID
-        Returns:
-          License
-    """
-    try:
-        data = DL.get_doi_record(pmcid, source='pmc')
-    except Exception as err:
-        LOGGER.debug(f"Could not get PMC license for {pmcid}: {err}")
-        COUNT['pmc_error'] += 1
-        return None
-    if not data or 'OAI-PMH' not in data or 'GetRecord' not in data['OAI-PMH'] \
-       or 'record' not in data['OAI-PMH']['GetRecord'] \
-       or 'metadata' not in data['OAI-PMH']['GetRecord']['record'] \
-       or 'article' not in data['OAI-PMH']['GetRecord']['record']['metadata'] \
-       or 'front' not in data['OAI-PMH']['GetRecord']['record']['metadata']['article']:
-        return None
-    front = data['OAI-PMH']['GetRecord']['record']['metadata']['article']['front']
-    if 'article-meta' not in front or 'custom-meta-group' not in front['article-meta'] \
-       or 'custom-meta' not in front['article-meta']['custom-meta-group'] \
-        or not front['article-meta']['custom-meta-group']['custom-meta']:
-        return None
-    custom_meta_list = front['article-meta']['custom-meta-group']['custom-meta']
-    if isinstance(custom_meta_list, dict):
-        custom_meta_list = [custom_meta_list]
-    for custom_meta in custom_meta_list:
-        if custom_meta['meta-name'] == 'license':
-            return custom_meta['meta-value'].replace(" ", "-").lower()
-    return None
-
-
-def get_unpaywall_license(doi):
-    """ Get the license for a DOI from Unpaywall
-        Keyword arguments:
-          doi: DOI
-        Returns:
-          License string or None
-    """
-    try:
-        data = DL.get_doi_record(doi, source='unpaywall')
-    except Exception as err:
-        LOGGER.debug(f"Could not get Unpaywall license for {doi}: {err}")
-        COUNT['unpaywall_error'] += 1
-        return None
-    if not data:
-        return None
-    best = data.get('best_oa_location') or {}
-    if best.get('license'):
-        return best['license']
-    for loc in data.get('oa_locations', []):
-        if loc.get('license'):
-            return loc['license']
-    return None
-
-
 def update_processing(doi, action, notes=None):
     ''' Update the processing status for a DOI
         Keyword arguments:
@@ -183,99 +134,56 @@ def update_processing(doi, action, notes=None):
         terminate_program(err)
 
 
-def update_datacite_license(row):
-    """ Update jrc_license from DataCite rightsList
-        Keyword arguments:
-          row: row to update from dois collection
-        Returns:
-          None
-    """
-    if row.get('jrc_license'):
-        return
-    payload = {}
-    if 'rightsList' in row and row['rightsList']:
-        for right in row['rightsList']:
-            if 'rightsIdentifier' in right and right['rightsIdentifier'] in LICENSE:
-                payload['jrc_license'] = LICENSE[right['rightsIdentifier']]
-                LOGGER.info(f"Using license (rightsIdentifier) {payload['jrc_license']} " \
-                            + f"for {row['doi']}")
-                break
-            elif 'rights' in right and right['rights'] in LICENSE:
-                payload['jrc_license'] = LICENSE[right['rights']]
-                LOGGER.info(f"Using license (rights) {payload['jrc_license']} for {row['doi']}")
-    if payload:
-        write_record(row, payload)
-        update_processing(row['doi'], 'sync_openaccess_license',
-                          f"update_datacite_license: {payload['jrc_license']}")
-
-
-def update_open_access(row):
-    """ Update jrc_is_oa and jrc_oa_status
+def update_open_access(row):  # pylint: disable=too-many-branches,too-many-statements
+    """ Update jrc_is_oa, jrc_oa_status, and jrc_license
         Keyword arguments:
           row: row to update from dois collection
         Returns:
           None
     """
     payload = {}
-    if 'jrc_obtained_from' in row and row['jrc_obtained_from'] == 'DataCite':
-        update_datacite_license(row)
-    time.sleep(.05)
     if not row.get('jrc_oa_status') and row.get('jrc_journal') and row['jrc_journal'] in JOURNAL:
         row['jrc_is_oa'] = True
         payload['jrc_is_oa'] = True
         row['jrc_oa_status'] = JOURNAL[row['jrc_journal']]
         payload['jrc_oa_status'] = JOURNAL[row['jrc_journal']]
         LOGGER.warning(f"Using journal OA status {row['jrc_oa_status']} for {row['doi']}")
-    data = DL.get_doi_record(row['doi'], source='openalex')
-    if not data:
+    time.sleep(.05)
+    data, openalex_unreachable = DISL.get_openalex_record(row['doi'])
+    if openalex_unreachable:
+        COUNT['openalex_unreachable'] += 1
+    elif not data:
         if not ARG.SILENT:
             LOGGER.warning(f"{row['doi']} was not found in OpenAlex")
         COUNT["notfound"] += 1
+    else:
+        try:
+            if 'open_access' in data and data['open_access']:
+                if 'jrc_is_oa' not in row:
+                    payload['jrc_is_oa'] = bool(data['open_access']['is_oa'])
+                if 'jrc_oa_status' not in row:
+                    payload['jrc_oa_status'] = data['open_access']['oa_status']
+        except Exception as err:
+            LOGGER.error(f"Could not process {row['doi']}")
+            terminate_program(err)
+    # License -- tries DataCite rightsList, OpenAlex (reusing the fetch above), PMC, Unpaywall
+    if not row.get('jrc_license'):
+        result = DISL.resolve_license(row, LICENSE, openalex_data=data)
+        if result.mapped:
+            payload['jrc_license'] = result.mapped
+        if result.pmc_skipped_no_id:
+            COUNT['pmc_skipped_no_id'] += 1
+        if result.pmc_429_exhausted:
+            COUNT['pmc_429_exhausted'] += 1
+        if result.pmc_unreachable:
+            COUNT['pmc_unreachable'] += 1
+        if result.unpaywall_not_indexed:
+            COUNT['unpaywall_not_indexed'] += 1
+        if result.unpaywall_unreachable:
+            COUNT['unpaywall_unreachable'] += 1
+    if not payload:
         return
-    try_pmc = True
-    try:
-        # Open Access
-        if 'open_access' in data and data['open_access']:
-            if 'jrc_is_oa' not in row:
-                payload['jrc_is_oa'] = bool(data['open_access']['is_oa'])
-            if 'jrc_oa_status' not in row:
-                payload['jrc_oa_status'] = data['open_access']['oa_status']
-        # License
-        if ('jrc_license' not in row or not row['jrc_license']) \
-           and 'primary_location' in data and data['primary_location'] \
-           and data['primary_location']['license'] \
-           and data['primary_location']['license'] != "False":
-            if data['primary_location']['license'] in LICENSE:
-                payload['jrc_license'] = LICENSE[data['primary_location']['license']]
-                LOGGER.info(f"Using license (primary_location) {payload['jrc_license']} " \
-                            + f"for {row['doi']}")
-                try_pmc = False
-            else:
-                LOGGER.warning(f"Unknown license {data['primary_location']['license']} " \
-                               + f"for {row['doi']}")
-        if ('jrc_license' not in payload or payload['jrc_license'] is None) and try_pmc \
-           and 'jrc_pmc' in row:
-            alt = get_pmc_license(row['jrc_pmc'])
-            if alt:
-                if alt in LICENSE:
-                    payload['jrc_license'] = LICENSE[alt]
-                    LOGGER.info(f"Using PMC license for {row['doi']}: {alt}")
-                else:
-                    LOGGER.warning(f"Unknown PMC license {alt} for {row['doi']}")
-        if ('jrc_license' not in payload or payload['jrc_license'] is None) and try_pmc:
-            alt = get_unpaywall_license(row['doi'])
-            if alt:
-                if alt in LICENSE:
-                    payload['jrc_license'] = LICENSE[alt]
-                    LOGGER.info(f"Using Unpaywall license for {row['doi']}: {alt}")
-                else:
-                    LOGGER.warning(f"Unknown Unpaywall license {alt} for {row['doi']}")
-        if not payload:
-            return
-    except Exception as err:
-        LOGGER.error(f"Could not process {row['doi']}")
-        terminate_program(err)
-    if data.get('id'):
+    if data and data.get('id'):
         payload['jrc_openalex_id'] = data['id']
     write_record(row, payload)
     notes = "update_openalex"
@@ -336,10 +244,18 @@ def show_counts():
     msg = f"DOIs read:      {COUNT['dois']:,}\n"
     if COUNT['notfound']:
         msg += f"DOIs not found: {COUNT['notfound']:,}\n"
-    if COUNT['pmc_error']:
-        msg += f"PMC errors:       {COUNT['pmc_error']:,}\n"
-    if COUNT['unpaywall_error']:
-        msg += f"Unpaywall errors: {COUNT['unpaywall_error']:,}\n"
+    if COUNT['pmc_skipped_no_id']:
+        msg += f"DOIs with no PMC ID:            {COUNT['pmc_skipped_no_id']:,}\n"
+    if COUNT['pmc_429_exhausted']:
+        msg += f"DOIs with PMC 429 exhausted:    {COUNT['pmc_429_exhausted']:,}\n"
+    if COUNT['pmc_unreachable']:
+        msg += f"DOIs skipped (PMC down):        {COUNT['pmc_unreachable']:,}\n"
+    if COUNT['openalex_unreachable']:
+        msg += f"DOIs skipped (OpenAlex down):   {COUNT['openalex_unreachable']:,}\n"
+    if COUNT['unpaywall_not_indexed']:
+        msg += f"DOIs not indexed in Unpaywall:  {COUNT['unpaywall_not_indexed']:,}\n"
+    if COUNT['unpaywall_unreachable']:
+        msg += f"DOIs skipped (Unpaywall down):  {COUNT['unpaywall_unreachable']:,}\n"
     if COUNT['updated']:
         msg += f"DOIs updated:   {COUNT['updated']:,}\n"
     return msg
@@ -403,7 +319,9 @@ def process_dois():
     msg1 = show_counts()
     print(msg1)
     # Open Access status override
-    COUNT['dois'] = COUNT["updated"] = COUNT["notfound"] = 0
+    COUNT.update(dois=0, updated=0, notfound=0, pmc_skipped_no_id=0, pmc_429_exhausted=0,
+                 pmc_unreachable=0, openalex_unreachable=0, unpaywall_not_indexed=0,
+                 unpaywall_unreachable=0)
     if dois:
         rows = []
         for doi in dois:


### PR DESCRIPTION
Extract the DataCite rightsList -> OpenAlex -> PMC -> Unpaywall license waterfall out of sync_datacite_legal.py into a new dis_license_lib.py module shared with sync_openalex.py, eliminating two independently buggy copies of the same logic.

- Fix rightsList matching giving up on a whole entry (and the whole list) after the first unrecognized field instead of trying every field/entry.
- Switch PMC lookups from the legacy OAI-PMH endpoint (3 req/s, no API key support) to E-utilities efetch (db=pmc), which honors NCBI_API_KEY for a 10 req/s limit.
- Add a default request timeout (pyalex sets none) plus a circuit breaker for OpenAlex, PMC, and Unpaywall: a connection-level failure now skips that tier for the rest of the run instead of hanging for minutes or crashing the whole batch.
- Migrate sync_openalex.py onto the shared module, removing its duplicate rightsList/PMC/Unpaywall logic and fixing a coverage gap where PMC/Unpaywall were never tried when OpenAlex had no record at all for a DOI.

@stuarteberg