### PR TITLE
feat(sync-openalex): HTML summary email, hardening, unmapped-license triage

### DIFF
--- a/sync/bin/sync_openalex.py
+++ b/sync/bin/sync_openalex.py
@@ -9,13 +9,19 @@
     the OA status is "closed" and the DOI has a fulltext URL, the OA status will be set to
     "hybrid" and jrc_is_oa will be set to True. The former status will be saved as
     jrc_former_status.
+
+    An HTML summary email is sent (when --test or --write is supplied and at least one DOI
+    was updated): a header banner (run data, DRY RUN/WRITE badge), KPI stat tiles, and two
+    Change Breakdown tables - one per pass (OA/license enrichment; OA-status override) -
+    with sync_openalex.json attached.
 """
 
-__version__ = '4.1.0'
+__version__ = '4.2.0'
 
 import argparse
 import collections
 from datetime import datetime
+import html
 import json
 from operator import attrgetter
 import os
@@ -35,6 +41,23 @@ LICENSE = {}
 JOURNAL = {}
 OUTPUT = []
 COUNT = collections.defaultdict(lambda: 0, {})
+# Unique raw license strings that couldn't be mapped ("Unknown ... license"),
+# excluding bare URLs (http/https...), for triage - shown in the console and email.
+UNKNOWN_LICENSES = set()
+# HTML run-summary email palette (generate_email and its html_* helpers). Mirrors
+# the sibling sync scripts: inline styles only (no <style> block/classes) for
+# reliable rendering across email clients including older Outlook.
+EMAIL_NAVY = '#1f3a5f'
+EMAIL_GREEN = '#1c7c3f'
+EMAIL_GREEN_BG = '#eefaf1'
+EMAIL_RED = '#c0392b'
+EMAIL_RED_BG = '#fdecea'
+EMAIL_AMBER = '#d68a1f'
+EMAIL_AMBER_BG = '#fdf3e0'
+EMAIL_GRAY = '#5b6b7c'
+EMAIL_GRAY_BG = '#f2f4f6'
+EMAIL_STRIPE_BG = '#f7f9fb'
+EMAIL_BORDER = '#eef1f4'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -157,15 +180,19 @@ def update_open_access(row):  # pylint: disable=too-many-branches,too-many-state
             LOGGER.warning(f"{row['doi']} was not found in OpenAlex")
         COUNT["notfound"] += 1
     else:
+        # Guard the open_access block with .get() so a missing key can't KeyError,
+        # and treat any other malformed-record error as a skip+count for this DOI
+        # rather than aborting the whole run.
         try:
-            if 'open_access' in data and data['open_access']:
-                if 'jrc_is_oa' not in row:
-                    payload['jrc_is_oa'] = bool(data['open_access']['is_oa'])
-                if 'jrc_oa_status' not in row:
-                    payload['jrc_oa_status'] = data['open_access']['oa_status']
+            oa = data.get('open_access') or {}
+            if 'jrc_is_oa' not in row and 'is_oa' in oa:
+                payload['jrc_is_oa'] = bool(oa['is_oa'])
+            if 'jrc_oa_status' not in row and oa.get('oa_status'):
+                payload['jrc_oa_status'] = oa['oa_status']
         except Exception as err:
-            LOGGER.error(f"Could not process {row['doi']}")
-            terminate_program(err)
+            LOGGER.error(f"Could not process OpenAlex data for {row['doi']}: {err}")
+            COUNT['openalex_error'] += 1
+            return
     # License -- tries DataCite rightsList, OpenAlex (reusing the fetch above), PMC, Unpaywall
     if not row.get('jrc_license'):
         result = DISL.resolve_license(row, LICENSE, openalex_data=data)
@@ -181,6 +208,10 @@ def update_open_access(row):  # pylint: disable=too-many-branches,too-many-state
             COUNT['unpaywall_not_indexed'] += 1
         if result.unpaywall_unreachable:
             COUNT['unpaywall_unreachable'] += 1
+        # Collect unmappable license slugs for triage, skipping bare URLs (http/https...)
+        for lic in result.unknown_licenses:
+            if lic and not lic.startswith('http'):
+                UNKNOWN_LICENSES.add(lic)
     if not payload:
         return
     if data and data.get('id'):
@@ -252,6 +283,8 @@ def show_counts():
         msg += f"DOIs skipped (PMC down):        {COUNT['pmc_unreachable']:,}\n"
     if COUNT['openalex_unreachable']:
         msg += f"DOIs skipped (OpenAlex down):   {COUNT['openalex_unreachable']:,}\n"
+    if COUNT['openalex_error']:
+        msg += f"DOIs with OpenAlex parse error: {COUNT['openalex_error']:,}\n"
     if COUNT['unpaywall_not_indexed']:
         msg += f"DOIs not indexed in Unpaywall:  {COUNT['unpaywall_not_indexed']:,}\n"
     if COUNT['unpaywall_unreachable']:
@@ -261,19 +294,190 @@ def show_counts():
     return msg
 
 
-def generate_email(counts):
-    ''' Generate and send an email
+def html_kpi_card(value, label, tone='neutral'):
+    ''' Build one KPI stat tile for the run-summary email's header row. A single
+        <td> carries the box look directly (bgcolor + background-color, no nested
+        table) - Outlook's Word engine chokes on a percentage-width table nested
+        in a percentage-width <td>.
         Keyword arguments:
-          counts: counts message
+          value: display value (already formatted)
+          label: caption under the value
+          tone: 'neutral', 'good', 'amber', or 'bad' - selects the color scheme
+        Returns:
+          HTML for one table cell
+    '''
+    bg, fg = {'good': (EMAIL_GREEN_BG, EMAIL_GREEN),
+              'bad': (EMAIL_RED_BG, EMAIL_RED),
+              'amber': (EMAIL_AMBER_BG, EMAIL_AMBER),
+              'neutral': (EMAIL_GRAY_BG, EMAIL_GRAY)}[tone]
+    return (f'<td width="25%" align="center" valign="top" bgcolor="{bg}" '
+            f'style="padding:14px 6px;background-color:{bg};border-radius:8px;">'
+            f'<div style="font-size:24px;font-weight:700;color:{fg};">{value}</div>'
+            f'<div style="font-size:10.5px;color:{EMAIL_GRAY};text-transform:uppercase;'
+            f'letter-spacing:.04em;margin-top:2px;">{label}</div>'
+            f'</td>')
+
+
+def html_section_header(title):
+    ''' Build a section header bar. Table-based (not a bare <div>) so it never
+        sits as a naked div immediately before a sibling <table> in the same <td>
+        - Outlook's Word engine can misparse that boundary and leak a stray
+        closing tag as literal text. The spacer row substitutes for CSS
+        margin-bottom, which <td> doesn't honor.
+        Keyword arguments:
+          title: section title (may include an HTML entity icon prefix)
+        Returns:
+          HTML table block
+    '''
+    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0">'
+            f'<tr><td style="font-size:14px;font-weight:700;color:{EMAIL_NAVY};'
+            f'border-bottom:2px solid {EMAIL_BORDER};padding-bottom:7px;">'
+            f'{title}</td></tr>'
+            '<tr><td style="height:10px;line-height:10px;font-size:1px;">&nbsp;</td></tr>'
+            '</table>')
+
+
+def html_metric_rows(rows):
+    ''' Build a zebra-striped label/value table. No per-cell border-radius:
+        Outlook's Word engine can leak a cell's opening tag as literal text in
+        tables repeating the same complex inline style across many rows, so cells
+        use plain background-color striping. A trailing spacer row absorbs the
+        last-row-before-</table> boundary (see html_section_header).
+        Keyword arguments:
+          rows: list of (label, value) pairs
+        Returns:
+          HTML table
+    '''
+    trs = []
+    for i, (mlabel, value) in enumerate(rows):
+        bgattr = f' bgcolor="{EMAIL_STRIPE_BG}"' if i % 2 == 0 else ''
+        bg = f'background-color:{EMAIL_STRIPE_BG};' if i % 2 == 0 else ''
+        trs.append(f'<tr{bgattr} style="{bg}">'
+                   f'<td style="padding:8px 10px;">{mlabel}</td>'
+                   f'<td align="right" style="padding:8px 10px;text-align:right;">'
+                   f'{value}</td></tr>')
+    trs.append('<tr><td colspan="2" style="height:1px;line-height:1px;font-size:1px;">'
+               '&nbsp;</td></tr>')
+    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+            'style="border-collapse:collapse;font-size:13px;margin-top:6px;">'
+            + "".join(trs) + '</table>')
+
+
+def html_license_list(licenses):
+    ''' Build a single-column table of unmapped license strings (monospace),
+        with no row striping. Trailing spacer row per the Outlook-safe convention
+        (see html_metric_rows).
+        Keyword arguments:
+          licenses: sorted list of license strings
+        Returns:
+          HTML table
+    '''
+    rows = []
+    for lic in licenses:
+        rows.append('<tr><td style="padding:6px 10px;'
+                    f'font-family:Menlo,Consolas,monospace;">{html.escape(lic)}</td></tr>')
+    rows.append('<tr><td style="height:1px;line-height:1px;font-size:1px;">&nbsp;</td></tr>')
+    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+            'style="border-collapse:collapse;font-size:12.5px;">'
+            + "".join(rows) + '</table>')
+
+
+def generate_email(pass1, pass2, unknown_licenses):
+    ''' Generate and send the HTML run-summary email: a header banner (run data,
+        DRY RUN/WRITE badge), KPI stat tiles, two Change Breakdown tables (one
+        for the OA/license pass and one for the OA-status-override pass), and -
+        when any were found - an Unmapped Licenses list. Built entirely from
+        inline styles/tables (no <style> block) for compatibility with older
+        email clients, matching the sibling sync scripts.
+        Keyword arguments:
+          pass1: counts snapshot from the OA/license pass
+          pass2: counts snapshot from the OA-status-override pass
+          unknown_licenses: sorted list of unmapped license strings (may be empty)
         Returns:
           None
     '''
-    msg = JRC.get_run_data(__file__, __version__) + "<br><br>" + counts.replace("\n", "<br>")
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_badge_bg = EMAIL_GREEN if ARG.WRITE else EMAIL_AMBER
+    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    if ARG.DOI:
+        restrict = f' &middot; doi: {ARG.DOI}'
+    elif ARG.FILE:
+        restrict = f' &middot; file: {os.path.basename(ARG.FILE)}'
+    elif ARG.NEW:
+        restrict = ' &middot; --new'
+    else:
+        restrict = ''
+    kpis = ''.join([
+        html_kpi_card(f"{pass1.get('dois', 0):,}", "DOIs read"),
+        html_kpi_card(f"{pass1.get('updated', 0):,}", "OA/license set",
+                      'good' if pass1.get('updated') else 'neutral'),
+        html_kpi_card(f"{pass2.get('updated', 0):,}", "OA overrides",
+                      'good' if pass2.get('updated') else 'neutral'),
+        html_kpi_card(f"{pass1.get('notfound', 0):,}", "Not in OpenAlex",
+                      'amber' if pass1.get('notfound') else 'neutral'),
+    ])
+    oa_rows = [
+        ("DOIs read", f"{pass1.get('dois', 0):,}"),
+        ("OA / license set", f"{pass1.get('updated', 0):,}"),
+        ("Not found in OpenAlex", f"{pass1.get('notfound', 0):,}"),
+        ("OpenAlex parse errors", f"{pass1.get('openalex_error', 0):,}"),
+        ("OpenAlex unreachable", f"{pass1.get('openalex_unreachable', 0):,}"),
+        ("No PMC ID", f"{pass1.get('pmc_skipped_no_id', 0):,}"),
+        ("PMC 429 exhausted", f"{pass1.get('pmc_429_exhausted', 0):,}"),
+        ("PMC unreachable", f"{pass1.get('pmc_unreachable', 0):,}"),
+        ("Unpaywall not indexed", f"{pass1.get('unpaywall_not_indexed', 0):,}"),
+        ("Unpaywall unreachable", f"{pass1.get('unpaywall_unreachable', 0):,}"),
+    ]
+    override_rows = [
+        ("DOIs read", f"{pass2.get('dois', 0):,}"),
+        ("Closed &rarr; hybrid overrides", f"{pass2.get('updated', 0):,}"),
+    ]
+    oa_section = (html_section_header("&#128220; Open Access / License")
+                  + html_metric_rows(oa_rows))
+    override_section = (html_section_header("&#128260; OA Status Override")
+                        + html_metric_rows(override_rows))
+    unknown_block = ''
+    if unknown_licenses:
+        unknown_block = (
+            '<tr><td style="padding:20px 28px 4px 28px;">'
+            + html_section_header(f"&#10067; Unmapped Licenses ({len(unknown_licenses):,})")
+            + html_license_list(unknown_licenses)
+            + '</td></tr>')
+    msg = (
+        f'<div style="font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;'
+        f'background-color:#eef1f4;padding:8px 0;">'
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>'
+        '<td align="center" style="padding:8px 14px 32px 14px;">'
+        '<table role="presentation" width="720" cellpadding="0" cellspacing="0" bgcolor="#ffffff" '
+        f'style="max-width:720px;width:100%;background-color:#ffffff;border-radius:10px;'
+        f'border:1px solid {EMAIL_BORDER};overflow:hidden;">'
+        f'<tr><td bgcolor="{EMAIL_NAVY}" style="background-color:{EMAIL_NAVY};padding:22px 28px;">'
+        f'<div style="color:#ffffff;font-size:19px;font-weight:600;">'
+        f'{os.path.basename(__file__)}&nbsp;'
+        f'<span style="font-weight:400;opacity:.7;font-size:14px;">v{__version__}</span></div>'
+        f'<div style="color:#c9d6e6;font-size:12.5px;margin-top:6px;">{run_data} &middot; '
+        f'manifold: {ARG.MANIFOLD}{restrict} &middot; '
+        f'<span style="background-color:{mode_badge_bg};color:#fff;border-radius:10px;'
+        f'padding:1px 9px;font-size:11px;font-weight:600;letter-spacing:.03em;">'
+        f'{mode_label}</span></div></td></tr>'
+        f'<tr><td style="padding:22px 22px 6px 22px;">'
+        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="6"><tr>'
+        f'{kpis}</tr></table></td></tr>'
+        f'<tr><td style="padding:18px 28px 4px 28px;">{oa_section}</td></tr>'
+        f'<tr><td style="padding:20px 28px 4px 28px;">{override_section}</td></tr>'
+        f'{unknown_block}'
+        f'<tr><td bgcolor="{EMAIL_STRIPE_BG}" style="padding:18px 28px;'
+        f'background-color:{EMAIL_STRIPE_BG};color:{EMAIL_GRAY};'
+        f'font-size:11px;text-align:center;border-top:1px solid {EMAIL_BORDER};">'
+        'Generated by sync_openalex.py &middot; Data and Information Services '
+        '&middot; Janelia Research Campus</td></tr>'
+        '</table></td></tr></table></div>')
+    subject = "OpenAlex OA/license sync"
+    email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
+    attach = 'sync_openalex.json' if os.path.exists('sync_openalex.json') else None
     try:
-        email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'attachment': 'sync_openalex.json', 'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "OpenAlex OA/license sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, subject, attachment=attach, mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()
@@ -316,12 +520,11 @@ def process_dois():
     for row in tqdm(rows, total=cnt, desc="Add OpenAlex"):
         COUNT['dois'] += 1
         update_open_access(row)
-    msg1 = show_counts()
-    print(msg1)
-    # Open Access status override
-    COUNT.update(dois=0, updated=0, notfound=0, pmc_skipped_no_id=0, pmc_429_exhausted=0,
-                 pmc_unreachable=0, openalex_unreachable=0, unpaywall_not_indexed=0,
-                 unpaywall_unreachable=0)
+    pass1 = dict(COUNT)
+    print(show_counts())
+    # Open Access status override. Reset the counters with clear() (rather than a
+    # hand-maintained key list that can drift) for a clean second-pass tally.
+    COUNT.clear()
     if dois:
         rows = []
         for doi in dois:
@@ -344,16 +547,21 @@ def process_dois():
         if 'jrc_oa_status' not in row or not row['jrc_oa_status']:
             continue
         COUNT["dois"] += 1
-        if row['jrc_oa_status'] == "closed" and row['jrc_fulltext_url']:
+        if row['jrc_oa_status'] == "closed" and row.get('jrc_fulltext_url'):
             override_oa_closed(row)
-    msg2 = show_counts()
-    print(msg2)
+    pass2 = dict(COUNT)
+    print(show_counts())
+    unknown_licenses = sorted(UNKNOWN_LICENSES)
+    if unknown_licenses:
+        print(f"Unmapped licenses ({len(unknown_licenses):,}):")
+        for lic in unknown_licenses:
+            print(f"  {lic}")
     if OUTPUT:
         LOGGER.info("Writing output to sync_openalex.json")
         with open('sync_openalex.json', 'w', encoding='utf-8') as fileout:
             json.dump(OUTPUT, fileout, indent=4)
         if ARG.TEST or ARG.WRITE:
-            generate_email(f"Updating Open Access/license data:\n{msg1}\nFixing OA status:\n{msg2}")
+            generate_email(pass1, pass2, unknown_licenses)
     if not ARG.WRITE:
         LOGGER.warning("Dry run successful, no updates were made")
 


### PR DESCRIPTION
## sync_openalex.py: HTML summary email, hardening, unmapped-license triage (v4.2.0)

> ⚠️ **Depends on #366** (`dis_license_lib.py` — `LicenseResult.unknown_licenses`). **Merge #366 first**; this branch alone references a field that doesn't exist on `main` yet.

### Email
- Replaces the plain-text `<br>` body with a full **HTML run-summary** (house style, matching the other sync scripts): header banner + DRY RUN/WRITE badge, KPI stat tiles, and two **Change Breakdown** tables — one for the OA/license pass, one for the OA-status-override pass — with `sync_openalex.json` attached.

### Hardening (deep-dive findings)
- Pass-2 guard uses `row.get('jrc_fulltext_url')`, so a `closed` DOI without a fulltext URL on the `--doi`/`--file` path no longer `KeyError`s.
- The OpenAlex `open_access` parse is `.get()`-guarded and wrapped so a malformed record is **skipped + counted** (`openalex_error`) instead of `terminate_program` aborting the whole run.
- Per-pass counters reset via `COUNT.clear()` rather than a hand-maintained key list that can drift.

### Unmapped-license triage
- Collects the unique raw license strings that couldn't be mapped (the *"Unknown … license"* cases), **excluding bare URLs (`http`/`https`…)**, and — when any are found — displays them in the console and in an **Unmapped Licenses** section of the email. Produces a ready-to-triage list of slugs (`cc-by-nc-nd-3.0`, …) to add to the license map.

### Verification
Mocked runs: findings 1 & 2 (incl. the previously-crashing missing-`is_oa` case), the dedup + `http`/`https` exclusion, and a balanced-HTML render of the email with and without the unmapped-license section. Syntax + pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
