### PR TITLE
fix(sync-email): drop table margin-top that leaked stray closing tags in Outlook

### DIFF
--- a/sync/bin/add_people_to_orcid.py
+++ b/sync/bin/add_people_to_orcid.py
@@ -12,7 +12,7 @@
     their organization is on the ignore list.
 '''
 
-__version__ = '7.3.0'
+__version__ = '7.3.1'
 
 import argparse
 import collections
@@ -364,9 +364,14 @@ def html_metric_rows(rows):
         documents with many rows repeating the same complex inline style
         (confirmed via a real Outlook test - a trailing spacer row alone did
         not fix it), so cells here use only plain background-color striping,
-        which Word handles reliably. A trailing throwaway spacer row is kept
-        anyway as cheap insurance against the last-row-before-</table>
-        boundary (see html_section_header).
+        which Word handles reliably. Also no margin-top on the table itself
+        (html_section_header's trailing spacer row already provides that
+        gap) - confirmed via a real Outlook test that a <table> carrying its
+        own margin-top, sitting immediately after a sibling table's
+        </table>, leaks a stray closing tag as literal visible text. A
+        trailing throwaway spacer row is kept anyway as cheap insurance
+        against the last-row-before-</table> boundary (see
+        html_section_header).
         Keyword arguments:
           rows: list of (label, value_html) pairs
         Returns:
@@ -384,7 +389,7 @@ def html_metric_rows(rows):
     trs.append('<tr><td colspan="2" style="height:1px;line-height:1px;font-size:1px;">'
                '&nbsp;</td></tr>')
     return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
-            'style="border-collapse:collapse;font-size:13px;margin-top:6px;">'
+            'style="border-collapse:collapse;font-size:13px;">'
             + "".join(trs) + '</table>')
 
 

--- a/sync/bin/apply_orcids.py
+++ b/sync/bin/apply_orcids.py
@@ -10,7 +10,7 @@
     linked to orcid.org).
 '''
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 import argparse
 import collections
@@ -361,8 +361,13 @@ def html_metric_rows(rows):
     ''' Build a zebra-striped label/value table. No per-cell border-radius:
         Outlook's Word engine can leak a cell's opening tag as literal text in
         tables that repeat the same complex inline style across many rows, so
-        cells use only plain background-color striping. A trailing spacer row
-        absorbs the last-row-before-</table> boundary (see html_section_header).
+        cells use only plain background-color striping. Also no margin-top on
+        the table itself (html_section_header's trailing spacer row already
+        provides that gap) - confirmed via a real Outlook test that a <table>
+        carrying its own margin-top, sitting immediately after a sibling
+        table's </table>, leaks a stray closing tag as literal visible text.
+        A trailing spacer row absorbs the last-row-before-</table> boundary
+        (see html_section_header).
         Keyword arguments:
           rows: list of (label, value) pairs
         Returns:
@@ -379,7 +384,7 @@ def html_metric_rows(rows):
     trs.append('<tr><td colspan="2" style="height:1px;line-height:1px;font-size:1px;">'
                '&nbsp;</td></tr>')
     return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
-            'style="border-collapse:collapse;font-size:13px;margin-top:6px;">'
+            'style="border-collapse:collapse;font-size:13px;">'
             + "".join(trs) + '</table>')
 
 

--- a/sync/bin/update_janelians_from_people.py
+++ b/sync/bin/update_janelians_from_people.py
@@ -36,7 +36,7 @@ With Changes table listing every updated author (linked to their /userui/
 record) with a plain-English diff of exactly what changed on their record.
 """
 
-__version__ = '6.3.0'
+__version__ = '6.3.1'
 
 import argparse
 import collections
@@ -466,7 +466,12 @@ def html_section_header(title):
 
 
 def html_metric_rows(rows):
-    ''' Build a zebra-striped label/value table for the run-summary email
+    ''' Build a zebra-striped label/value table for the run-summary email.
+        No margin-top on the table itself (html_section_header's trailing
+        spacer row already provides that gap) - confirmed via a real Outlook
+        test that a <table> carrying its own margin-top, sitting immediately
+        after a sibling table's </table>, leaks a stray closing tag as
+        literal visible text.
         Keyword arguments:
           rows: list of (label, value_html) pairs
         Returns:
@@ -484,7 +489,7 @@ def html_metric_rows(rows):
                    f'<td align="right" style="padding:8px 10px;text-align:right;{r_r}">'
                    f'{value}</td></tr>')
     return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
-            'style="border-collapse:collapse;font-size:13px;margin-top:6px;">'
+            'style="border-collapse:collapse;font-size:13px;">'
             + "".join(trs) + '</table>')
 
 


### PR DESCRIPTION
html_metric_rows built its <table> with an inline margin-top, sitting flush against the preceding section header's </table>. Outlook Desktop for Mac's Word rendering engine misparses that boundary and renders a literal "</table>" in the email body (seen in add_people_to_orcid.py's Change Breakdown section). html_section_header already appends a spacer row for that gap, so the margin-top was redundant as well as unsafe. Removed it from the shared html_metric_rows helper in add_people_to_orcid.py, update_janelians_from_people.py, and apply_orcids.py, and bumped each script's version.

@stuarteberg