### PR TITLE
feat(email): rebuild sync/bin pull-program emails on the jrc_email house style

### DIFF
--- a/sync/bin/pull_arxiv.py
+++ b/sync/bin/pull_arxiv.py
@@ -23,6 +23,7 @@ An HTML summary email is sent when --test or --write is supplied.
 import argparse
 import collections
 import json
+import os
 from operator import attrgetter
 import re
 import sys
@@ -32,10 +33,11 @@ import requests
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 # Database
 DB = {}
@@ -237,64 +239,52 @@ def parse_authors(doi, msg, ready, review):
     return False
 
 
-def doiurl(doi):
-    ''' Format a DOI as an HTML link
-        Keyword arguments:
-          doi: DOI to format
-        Returns:
-          Formatted HTML anchor tag
-    '''
-    return f"&nbsp;&nbsp;<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
-
-
-def text_to_html_table(text):
-    ''' Convert colon-delimited text lines to an HTML table
-        Keyword arguments:
-          text: text to convert
-        Returns:
-          HTML table string
-    '''
-    rows = []
-    for line in text.strip().splitlines():
-        if ":" in line:
-            label, value = line.rsplit(":", 1)
-            rows.append((label.strip(), value.strip()))
-    html = ['<table>']
-    for label, value in rows:
-        html.append(f'  <tr><td>{label}:</td><td>{value}</td></tr>')
-    html.append('</table>')
-    return "\n".join(html)
-
-
 def generate_email(ready, review, summary):
-    ''' Generate and send a summary email
+    ''' Generate and send the HTML run-summary email (jrc_email house style): a
+        header banner, a KPI stat-tile row, a "Ready for Processing" card, and -
+        when any - a "Requiring Review" card. Recipient is the developer for --test
+        and the receivers list otherwise.
         Keyword arguments:
           ready: list of DOIs ready for processing
           review: list of DOIs requiring review
-          summary: plain-text run summary
+          summary: text summary (printed to the console; not used in the email body)
         Returns:
           None
     '''
-    msg = ""
-    if ready:
-        msg += "<br>The following DOIs are ready for processing:<br>"
-        for doi in ready:
-            msg += doiurl(doi)
-        msg += "<br>"
-    if review:
-        msg += "<br>The following DOIs require review:<br>"
-        for doi in review:
-            msg += doiurl(doi)
-        msg += "<br>"
-    if not msg:
+    if not ready and not review:
         return
-    msg = JRC.get_run_data(__file__, __version__) + "<br><br>" \
-        + text_to_html_table(summary) + "<br>" + msg
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['read']:,}", "Read from arXiv"),
+        JE.kpi_card(f"{COUNT['in_dois']:,}", "Already in DB"),
+        JE.kpi_card(f"{COUNT['no_datacite']:,}", "Not in DataCite"),
+        JE.kpi_card(f"{len(review):,}", "Requiring review",
+                    'warn' if review else 'neutral'),
+        JE.kpi_card(f"{len(ready):,}", "Ready to process",
+                    'good' if ready else 'neutral'),
+    ])
+    ready_body = (JE.doi_card("Ready for Processing", [(d, None) for d in ready], 'good')
+                  if ready else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready for processing.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready for Processing ({len(ready):,})")
+                       + ready_body)
+    if review:
+        card = (JE.section_header(f"&#9888; Requiring Review ({len(review):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'A Janelia author could not be confirmed automatically - review before '
+                'ingesting.</div>'
+                + JE.doi_card("Requiring Review", [(d, None) for d in review], 'warn',
+                              icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "arXiv DOI sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, "arXiv DOI sync", mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()

--- a/sync/bin/pull_biorxiv.py
+++ b/sync/bin/pull_biorxiv.py
@@ -23,6 +23,7 @@ An HTML summary email is sent when --test or --write is supplied.
 
 import argparse
 import collections
+import os
 from datetime import date, timedelta
 from operator import attrgetter
 import sys
@@ -31,10 +32,11 @@ from time import sleep
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,duplicate-code
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 # Database
 DB = {}
@@ -211,64 +213,52 @@ def parse_authors(doi, msg, ready, review):
     return False
 
 
-def doiurl(doi):
-    ''' Format a DOI as an HTML link
-        Keyword arguments:
-          doi: DOI to format
-        Returns:
-          Formatted HTML anchor tag
-    '''
-    return f"&nbsp;&nbsp;<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
-
-
-def text_to_html_table(text):
-    ''' Convert colon-delimited text lines to an HTML table
-        Keyword arguments:
-          text: text to convert
-        Returns:
-          HTML table string
-    '''
-    rows = []
-    for line in text.strip().splitlines():
-        if ":" in line:
-            label, value = line.rsplit(":", 1)
-            rows.append((label.strip(), value.strip()))
-    html = ['<table>']
-    for label, value in rows:
-        html.append(f'  <tr><td>{label}:</td><td>{value}</td></tr>')
-    html.append('</table>')
-    return "\n".join(html)
-
-
 def generate_email(ready, review, summary):
-    ''' Generate and send a summary email
+    ''' Generate and send the HTML run-summary email (jrc_email house style): a
+        header banner, a KPI stat-tile row, a "Ready for Processing" card, and -
+        when any - a "Requiring Review" card. Recipient is the developer for --test
+        and the receivers list otherwise.
         Keyword arguments:
           ready: list of DOIs ready for processing
           review: list of DOIs requiring review
-          summary: plain-text run summary
+          summary: text summary (printed to the console; not used in the email body)
         Returns:
           None
     '''
-    msg = ""
-    if ready:
-        msg += "<br>The following DOIs are ready for processing:<br>"
-        for doi in ready:
-            msg += doiurl(doi)
-        msg += "<br>"
-    if review:
-        msg += "<br>The following DOIs require review:<br>"
-        for doi in review:
-            msg += doiurl(doi)
-        msg += "<br>"
-    if not msg:
+    if not ready and not review:
         return
-    msg = JRC.get_run_data(__file__, __version__) + "<br><br>" \
-        + text_to_html_table(summary) + "<br>" + msg
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['read']:,}", "Read from bioRxiv"),
+        JE.kpi_card(f"{COUNT['in_dois']:,}", "Already in DB"),
+        JE.kpi_card(f"{COUNT['no_crossref']:,}", "Not in Crossref"),
+        JE.kpi_card(f"{len(review):,}", "Requiring review",
+                    'warn' if review else 'neutral'),
+        JE.kpi_card(f"{len(ready):,}", "Ready to process",
+                    'good' if ready else 'neutral'),
+    ])
+    ready_body = (JE.doi_card("Ready for Processing", [(d, None) for d in ready], 'good')
+                  if ready else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready for processing.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready for Processing ({len(ready):,})")
+                       + ready_body)
+    if review:
+        card = (JE.section_header(f"&#9888; Requiring Review ({len(review):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'A Janelia author could not be confirmed automatically - review before '
+                'ingesting.</div>'
+                + JE.doi_card("Requiring Review", [(d, None) for d in review], 'warn',
+                              icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "bioRxiv DOI sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, "bioRxiv DOI sync", mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()

--- a/sync/bin/pull_figshare.py
+++ b/sync/bin/pull_figshare.py
@@ -38,16 +38,18 @@ An HTML summary email is sent when --test or --write is supplied.
 import argparse
 import collections
 import configparser
+import os
 from operator import attrgetter
 import sys
 import time
 import traceback
 import requests
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,duplicate-code
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 # Database
 DB = {}
@@ -206,67 +208,53 @@ def pull_single_group(dois, institution=None, group=None):
     LOGGER.info(f"Checked {checked:,} DOIs from figshare in {parts} part(s)")
 
 
-def doiurl(doi, mode='doi'):
-    ''' Format a DOI as an HTML link
-        Keyword arguments:
-          doi: DOI to format
-          mode: 'figshare' for raw figshare link, otherwise standard doiui link
-        Returns:
-          Formatted HTML anchor tag
-    '''
-    if mode == 'figshare':
-        return f"&nbsp;&nbsp;<a href='https://dis.int.janelia.org/raw/figshare/{doi}'>{doi}</a><br>"
-    return f"&nbsp;&nbsp;<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
-
-
-def text_to_html_table(text):
-    ''' Convert colon-delimited text lines to an HTML table
-        Keyword arguments:
-          text: text to convert
-        Returns:
-          HTML table string
-    '''
-    rows = []
-    for line in text.strip().splitlines():
-        if ":" in line:
-            label, value = line.rsplit(":", 1)
-            rows.append((label.strip(), value.strip()))
-    html = ['<table>']
-    for label, value in rows:
-        html.append(f'  <tr><td>{label}:</td><td>{value}</td></tr>')
-    html.append('</table>')
-    return "\n".join(html)
-
-
 def generate_email(ready, no_datacite, summary):
-    ''' Generate and send a summary email
+    ''' Generate and send the HTML run-summary email (jrc_email house style): a
+        header banner, a KPI stat-tile row, a "Ready for Processing" card, and -
+        when any - a "Not in DataCite" card (whose links go to the raw figshare
+        record, since those DOIs are not yet in DataCite). Recipient is the
+        developer for --test and the receivers list otherwise.
         Keyword arguments:
           ready: list of DOIs ready for processing
           no_datacite: list of DOIs not found in DataCite
-          summary: plain-text run summary
+          summary: text summary (printed to the console; not used in the email body)
         Returns:
           None
     '''
-    msg = ""
-    if ready:
-        msg += "<br>The following DOIs are ready for processing:<br>"
-        for doi in ready:
-            msg += doiurl(doi)
-        msg += "<br>"
-    if no_datacite:
-        msg += "<br>The following DOIs are not in DataCite:<br>"
-        for doi in no_datacite:
-            msg += doiurl(doi, mode='figshare')
-        msg += "<br>"
-    if not msg:
+    if not ready and not no_datacite:
         return
-    msg = JRC.get_run_data(__file__, __version__) + "<br><br>" \
-        + text_to_html_table(summary) + "<br>" + msg
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['checked']:,}", "Read from figshare"),
+        JE.kpi_card(f"{COUNT['janelia']:,}", "Janelia DOIs"),
+        JE.kpi_card(f"{COUNT['in_dois']:,}", "Already in DB"),
+        JE.kpi_card(f"{len(no_datacite):,}", "Not in DataCite",
+                    'warn' if no_datacite else 'neutral'),
+        JE.kpi_card(f"{len(ready):,}", "Ready to process",
+                    'good' if ready else 'neutral'),
+    ])
+    ready_body = (JE.doi_card("Ready for Processing", [(d, None) for d in ready], 'good')
+                  if ready else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready for processing.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready for Processing ({len(ready):,})")
+                       + ready_body)
+    if no_datacite:
+        card = (JE.section_header(f"&#9888; Not in DataCite ({len(no_datacite):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'These figshare DOIs are not yet registered in DataCite (links go to the '
+                'raw figshare record) - not ready to ingest.</div>'
+                + JE.doi_card("Not in DataCite", [(d, None) for d in no_datacite], 'warn',
+                              icon='&#9888;', base='https://dis.int.janelia.org/raw/figshare/'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "figshare DOI sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, "figshare DOI sync", mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()

--- a/sync/bin/pull_openalex.py
+++ b/sync/bin/pull_openalex.py
@@ -4,7 +4,7 @@
     - 
 '''
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 import argparse
 import collections
@@ -18,6 +18,7 @@ import requests
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,logging-fstring-interpolation
 
@@ -249,28 +250,44 @@ def generate_emails():
         Returns:
           None
     '''
-    msg = ""
-    if MESSAGE['ready']:
-        msg += "<br>The following DOIs will be added to the database:<br>"
-        for itm in MESSAGE['ready']:
-            msg += f"  {itm}<br>"
-        msg += "\n"
-    if msg:
-        msg = JRC.get_run_data(__file__, __version__) + "<br>" + msg
-    else:
+    if not OUTPUT['ready'] and not OUTPUT['review']:
         return
-    if MESSAGE['review']:
-        msg += "<br>The following DOIs should be reviewed:<br>"
-        for itm in MESSAGE['review']:
-            msg += f"  {itm}<br>"
-        msg += "\n"
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    ready = [(doi, OUTPUT['ready'][doi][0]) for doi in sorted(OUTPUT['ready'])]
+    review = [(doi, OUTPUT['review'][doi][0]) for doi in sorted(OUTPUT['review'])]
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['dois']:,}", "Found in OpenAlex"),
+        JE.kpi_card(f"{COUNT['in_database']:,}", "Already in DB"),
+        JE.kpi_card(f"{COUNT['no_author']:,}", "No Janelia author"),
+        JE.kpi_card(f"{len(review):,}", "Requiring review",
+                    'warn' if review else 'neutral'),
+        JE.kpi_card(f"{len(ready):,}", "Ready to add",
+                    'good' if ready else 'neutral'),
+    ])
+    ready_body = (JE.doi_card("Ready to Add", ready, 'good', second_header='Janelia author')
+                  if ready else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready to add.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready to Add ({len(ready):,})")
+                       + ready_body)
+    if review:
+        card = (JE.section_header(f"&#9888; Requiring Review ({len(review):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'A Janelia author could not be confirmed by ORCID or the People collection '
+                '- review before ingesting.</div>'
+                + JE.doi_card("Requiring Review", review, 'warn', second_header='Author',
+                              icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     with open('openalex_status.html', 'w', encoding='utf-8') as fileout:
         fileout.write(msg)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "Lab head DOI sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, "Lab head DOI sync", mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()

--- a/sync/bin/pull_openalex_labs.py
+++ b/sync/bin/pull_openalex_labs.py
@@ -6,7 +6,7 @@
     - The lab head (or any other author) has a Janelia affiliation
 '''
 
-__version__ = '6.1.0'
+__version__ = '6.2.0'
 
 import argparse
 import collections
@@ -20,6 +20,7 @@ import requests
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,logging-fstring-interpolation
 
@@ -303,30 +304,54 @@ def generate_emails():
         Returns:
           None
     '''
-    msg = ""
-    if MESSAGE['sent']:
-        msg += "<br>The following DOIs will be added to the database:<br>"
-        for itm in MESSAGE['sent']:
-            msg += f"  {itm}<br>"
-        msg += "\n"
-    if MESSAGE['no_institutions']:
-        msg += "<br>The following DOIs have no institutions:<br>"
-        for itm in MESSAGE['no_institutions']:
-            msg += f"  {itm}<br>"
-        msg += "\n"
-    if MESSAGE['institution_mismatch']:
-        msg += "<br>The following DOIs have an institution mismatch (also see attached file):<br>"
-        for itm in MESSAGE['institution_mismatch']:
-            msg += f"  {itm}<br>"
-    if msg:
-        msg = JRC.get_run_data(__file__, __version__) + "<br>" + msg
-    else:
+    if not (OUTPUT['sent'] or OUTPUT['no_institutions'] or OUTPUT['institution_mismatch']):
         return
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    sent = [(doi, OUTPUT['sent'][doi][0]) for doi in sorted(OUTPUT['sent'])]
+    noinst = [(doi, OUTPUT['no_institutions'][doi][0])
+              for doi in sorted(OUTPUT['no_institutions'])]
+    mismatch = [(doi, OUTPUT['institution_mismatch'][doi][0])
+                for doi in sorted(OUTPUT['institution_mismatch'])]
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['dois']:,}", "Found in OpenAlex"),
+        JE.kpi_card(f"{COUNT['in_database']:,}", "Already in DB"),
+        JE.kpi_card(f"{len(noinst):,}", "No institutions"),
+        JE.kpi_card(f"{len(mismatch):,}", "Inst. mismatch",
+                    'warn' if mismatch else 'neutral'),
+        JE.kpi_card(f"{len(sent):,}", "Ready to add",
+                    'good' if sent else 'neutral'),
+    ])
+    ready_body = (JE.doi_card("Ready to Add", sent, 'good', second_header='Janelia author')
+                  if sent else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready to add.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready to Add ({len(sent):,})")
+                       + ready_body)
+    if noinst:
+        card = (JE.section_header(f"&#9888; No Institutions ({len(noinst):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'OpenAlex lists no institution for the matched author - review before '
+                'ingesting.</div>'
+                + JE.doi_card("No Institutions", noinst, 'warn', second_header='Author',
+                              icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    if mismatch:
+        card = (JE.section_header(f"&#9888; Institution Mismatch ({len(mismatch):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'OpenAlex placed the matched author at a non-Janelia institution (see the '
+                'attached TSV) - review before ingesting.</div>'
+                + JE.doi_card("Institution Mismatch", mismatch, 'warn', second_header='Author',
+                              icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
         opts = {'mime': 'html'}
-        if MESSAGE['institution_mismatch']:
+        if OUTPUT['institution_mismatch']:
             opts['attachment'] = 'openalex_institution_mismatch.tsv'
         JRC.send_email(msg, DISCONFIG['sender'], email, "Lab head DOI sync", **opts)
     except Exception as err:

--- a/sync/bin/pull_protocolsio.py
+++ b/sync/bin/pull_protocolsio.py
@@ -37,11 +37,12 @@ from urllib.parse import urlsplit, urlunsplit
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 # Parms
 ARG = DISCONFIG = LOGGER = None
@@ -207,85 +208,86 @@ def parse_authors(doi, msg, ready, review, nojanelians, alumni):
     nojanelians.append(json.dumps(msg, indent=4, default=str))
 
 
-def doimsg(item):
-    ''' Format a DOI as a message
+def _bucket_dois(items):
+    ''' Extract lower-cased (doi, None) entries from a protocols.io bucket whose
+        items may be dicts or JSON strings.
         Keyword arguments:
-          item: item to format
+          items: list of dicts or JSON strings carrying a 'doi'
         Returns:
-          Formatted DOI
+          list of (doi, None) tuples for doi_card
     '''
-    if 'doi' not in item:
-        return ""
-    doi = item['doi'].lower()
-    return f"&nbsp;&nbsp;<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
-
-
-def text_to_html_table(text):
-    ''' Convert text to an HTML table
-        Keyword arguments:
-          text: text to convert
-        Returns:
-          HTML table
-    '''
-    rows = []
-    for line in text.strip().splitlines():
-        if ":" in line:
-            label, value = line.rsplit(":", 1)
-            rows.append((label.strip(), value.strip()))
-    html = ['<table>']
-    for label, value in rows:
-        html.append(f'  <tr><td>{label}:</td><td>{value}</td></tr>')
-    html.append('</table>')
-    return "\n".join(html)
+    entries = []
+    for item in items:
+        rec = json.loads(item) if isinstance(item, str) else item
+        if isinstance(rec, dict) and rec.get('doi'):
+            entries.append((rec['doi'].lower(), None))
+    return entries
 
 
 def generate_email(summary, ready, review, nojanelians, alumni):
-    ''' Generate and send an email
+    ''' Generate and send the HTML run-summary email (jrc_email house style): a
+        header banner, a KPI stat-tile row, a "Ready to Add" card, and - when any -
+        "Requiring Review", "Alumni Authors", and "No Janelian Authors" cards.
+        Recipient is the developer for --test and the receivers list otherwise; a
+        --write run with nothing ready or to review sends nothing.
         Keyword arguments:
-          summary: summary of the results
+          summary: text summary (printed to the console; not used in the email body)
           ready: list of DOIs ready for processing
-          review: list of DOIs requiring review
-          nojanelians: list of DOIs with no Janelian authors
-          alumni: list of DOIs with alumni authors
+          review: list of records requiring review
+          nojanelians: list of records with no Janelian authors
+          alumni: list of records whose only Janelian authors are alumni
         Returns:
           None
     '''
-    msg = ""
     if not ready and not review and ARG.WRITE:
         return
-    if ready:
-        msg += "<br>The following DOIs will be added to the database:<br>"
-        for item in ready:
-            msg += doimsg({"doi": item})
-        msg += "<br>"
-    if review:
-        msg += "<br>The following DOIs should be reviewed:<br>"
-        for item in review:
-            item_json = json.loads(item) if isinstance(item, str) else item
-            msg += doimsg(item_json)
-        msg += "<br>"
-    if nojanelians:
-        msg += "<br>The following DOIs have no Janelian authors:<br>"
-        for item in nojanelians:
-            item_json = json.loads(item) if isinstance(item, str) else item
-            msg += doimsg(item_json)
-        msg += "<br>"
-    if alumni:
-        msg += "<br>The following DOIs have alumni authors:<br>"
-        for item in alumni:
-            item_json = json.loads(item) if isinstance(item, str) else item
-            msg += doimsg(item_json)
-        msg += "<br>"
-    if msg:
-        msg = JRC.get_run_data(__file__, __version__) + "<br><br>" \
-            + text_to_html_table(summary) + "<br>" + msg
-    else:
+    if not (ready or review or nojanelians or alumni):
         return
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['read']:,}", "Read from protocols.io"),
+        JE.kpi_card(f"{COUNT['in_dois']:,}", "Already in DB"),
+        JE.kpi_card(f"{len(nojanelians):,}", "No Janelian"),
+        JE.kpi_card(f"{len(review):,}", "Requiring review",
+                    'warn' if review else 'neutral'),
+        JE.kpi_card(f"{len(ready):,}", "Ready to add",
+                    'good' if ready else 'neutral'),
+    ])
+    ready_entries = [(doi.lower(), None) for doi in ready]
+    ready_body = (JE.doi_card("Ready to Add", ready_entries, 'good')
+                  if ready_entries else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready to add.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready to Add ({len(ready):,})")
+                       + ready_body)
+    review_entries = _bucket_dois(review)
+    if review_entries:
+        card = (JE.section_header(f"&#9888; Requiring Review ({len(review_entries):,})")
+                + JE.doi_card("Requiring Review", review_entries, 'warn', icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    alumni_entries = _bucket_dois(alumni)
+    if alumni_entries:
+        card = (JE.section_header(f"&#127891; Alumni Authors ({len(alumni_entries):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'The only Janelian author(s) are alumni (former staff) - confirm before '
+                'ingesting.</div>'
+                + JE.doi_card("Alumni Authors", alumni_entries, 'warn', icon='&#127891;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    nojanelians_entries = _bucket_dois(nojanelians)
+    if nojanelians_entries:
+        card = (JE.section_header(f"&#128683; No Janelian Authors "
+                                  f"({len(nojanelians_entries):,})")
+                + JE.doi_card("No Janelian Authors", nojanelians_entries, 'warn',
+                              icon='&#128683;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "Protocols.io DOI sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, "Protocols.io DOI sync", mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()

--- a/sync/bin/pull_springer.py
+++ b/sync/bin/pull_springer.py
@@ -50,9 +50,10 @@ from operator import attrgetter
 import requests
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 # Global variables
 ARG = DISCONFIG = LOGGER = None
@@ -385,65 +386,52 @@ def janelia_authors(doi, msg):
     return janelians
 
 
-def doiurl(doi):
-    ''' Format a DOI as a URL
-        Keyword arguments:
-          doi: DOI to format
-        Returns:
-          Formatted DOI
-    '''
-    return f"&nbsp;&nbsp;<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
-
-
-def text_to_html_table(text):
-    ''' Convert text to an HTML table
-        Keyword arguments:
-          text: text to convert
-        Returns:
-          HTML table
-    '''
-    rows = []
-    for line in text.strip().splitlines():
-        if ":" in line:
-            label, value = line.rsplit(":", 1)
-            rows.append((label.strip(), value.strip()))
-    html = ['<table>']
-    for label, value in rows:
-        html.append(f'  <tr><td>{label}:</td><td>{value}</td></tr>')
-    html.append('</table>')
-    return "\n".join(html)
-
-
 def generate_email(ready, review, summary):
-    ''' Generate and send an email
+    ''' Generate and send the HTML run-summary email (jrc_email house style): a
+        header banner, a KPI stat-tile row, a "Ready for Processing" card, and -
+        when any - a "Requiring Review" card. Recipient is the developer for --test
+        and the receivers list otherwise.
         Keyword arguments:
           ready: list of records ready for processing
           review: list of records requiring manual review
-          summary: summary of the results
+          summary: text summary (printed to the console; not used in the email body)
         Returns:
           None
     '''
-    msg = ""
-    if ready:
-        msg += "<br>The following DOIs are ready for processing:<br>"
-        for rec in ready:
-            msg += doiurl(rec['doi'])
-        msg += "<br>"
-    if review:
-        msg += "<br>The following DOIs require review:<br>"
-        for rec in review:
-            msg += doiurl(rec['doi'])
-        msg += "<br>"
-    if msg:
-        msg = JRC.get_run_data(__file__, __version__) + "<br><br>" \
-            + text_to_html_table(summary) + "<br>" + msg
-    else:
+    if not ready and not review:
         return
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['total']:,}", "Read from Springer"),
+        JE.kpi_card(f"{COUNT['skipped_db']:,}", "Already in DB"),
+        JE.kpi_card(f"{COUNT['noauthors']:,}", "No Janelia authors"),
+        JE.kpi_card(f"{len(review):,}", "Requiring review",
+                    'warn' if review else 'neutral'),
+        JE.kpi_card(f"{len(ready):,}", "Ready to process",
+                    'good' if ready else 'neutral'),
+    ])
+    ready_body = (JE.doi_card("Ready for Processing", [(rec['doi'], None) for rec in ready], 'good')
+                  if ready else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready for processing.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready for Processing ({len(ready):,})")
+                       + ready_body)
+    if review:
+        card = (JE.section_header(f"&#9888; Requiring Review ({len(review):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'Janelia authorship matched only by name (not ORCID or asserted affiliation) '
+                '- review before ingesting.</div>'
+                + JE.doi_card("Requiring Review", [(rec['doi'], None) for rec in review], 'warn',
+                              icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "Springer DOI sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, "Springer DOI sync", mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()
@@ -492,6 +480,7 @@ def processing():
             ready.append(out)
         else:
             review.append(out)
+    COUNT['noauthors'] = len(noauthors)
     summary = f"DOIs read from Springer:        {COUNT['total']:,}\n" \
               + f"Skipped (no DOI):               {COUNT['no_doi']:,}\n" \
               + f"Skipped (duplicate in results): {COUNT['skipped_dup']:,}\n" \

--- a/sync/bin/pull_zenodo.py
+++ b/sync/bin/pull_zenodo.py
@@ -1,5 +1,10 @@
 ''' pull_zenodo.py
     Sync works from Zenodo.
+
+    Finds Zenodo records matching the search term whose creators have a Janelia
+    affiliation or a known Janelian ORCID, writes the new DOIs to zenodo_ready.txt,
+    and sends an HTML run-summary email (jrc_email house style) on --test (to the
+    developer) or --write (to the receivers list).
 '''
 
 import argparse
@@ -12,8 +17,9 @@ from time import sleep
 import traceback
 import requests
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,logging-fstring-interpolation
 
@@ -162,70 +168,55 @@ def get_dois():
     return dois
 
 
-def doimsg(doi):
-    ''' Format a DOI as an HTML link
-        Keyword arguments:
-          doi: DOI
-        Returns:
-          Formatted DOI
-    '''
-    if not doi:
-        return ""
-    doi = doi.lower()
-    return f"&nbsp;&nbsp;<a href='https://dis.int.janelia.org/doiui/{doi}'>{doi}</a><br>"
-
-
-def text_to_html_table(text):
-    ''' Convert text to an HTML table
-        Keyword arguments:
-          text: text to convert
-        Returns:
-          HTML table
-    '''
-    rows = []
-    for line in text.strip().splitlines():
-        if ":" in line:
-            label, value = line.rsplit(":", 1)
-            rows.append((label.strip(), value.strip()))
-    html = ['<table>']
-    for label, value in rows:
-        html.append(f'  <tr><td>{label}:</td><td>{value}</td></tr>')
-    html.append('</table>')
-    return "\n".join(html)
-
-
 def generate_email(summary, ready, nojanelia):
-    ''' Generate and send an email
+    ''' Generate and send the HTML run-summary email (jrc_email house style): a
+        header banner, a KPI stat-tile row, a "Ready to Add" card, and - when any -
+        a "No Janelia Affiliation" review card. Recipient is the developer for
+        --test and the receivers list otherwise; a --write run with nothing ready
+        sends nothing.
         Keyword arguments:
-          summary: summary of the results
+          summary: text summary (printed to the console; not used in the email body)
           ready: list of DOIs ready for processing
-          nojanelia: list of Zenodo records with no Janelian authors
+          nojanelia: list of Zenodo records with no Janelian author
         Returns:
           None
     '''
-    msg = ""
     if not ready and ARG.WRITE:
         return
-    if ready:
-        msg += "<br>The following DOIs will be added to the database:<br>"
-        for doi in ready:
-            msg += doimsg(doi)
-        msg += "<br>"
-    if nojanelia:
-        msg += "<br>The following DOIs have no Janelian authors:<br>"
-        for hit in nojanelia:
-            msg += doimsg(hit.get('doi', ''))
-        msg += "<br>"
-    if msg:
-        msg = JRC.get_run_data(__file__, __version__) + "<br><br>" \
-            + text_to_html_table(summary) + "<br>" + msg
-    else:
+    if not ready and not nojanelia:
         return
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'TEST' if ARG.TEST else 'LIVE'
+    mode_tone = 'warn' if ARG.TEST else 'good'
+    review = [(hit.get('doi', '').lower(), None) for hit in nojanelia if hit.get('doi')]
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['read']:,}", "In Zenodo"),
+        JE.kpi_card(f"{COUNT['already']:,}", "Already in DB"),
+        JE.kpi_card(f"{COUNT['ignored']:,}", "To ignore"),
+        JE.kpi_card(f"{len(nojanelia):,}", "No Janelia affil.",
+                    'warn' if nojanelia else 'neutral'),
+        JE.kpi_card(f"{len(ready):,}", "Ready to add",
+                    'good' if ready else 'neutral'),
+    ])
+    ready_body = (JE.doi_card("Ready to Add", [(doi, None) for doi in ready], 'good')
+                  if ready else
+                  f'<div style="color:{JE.GRAY};font-size:13px;">'
+                  'No new DOIs are ready to add.</div>')
+    body = JE.body_row(JE.section_header(f"&#10003; Ready to Add ({len(ready):,})")
+                       + ready_body)
+    if review:
+        card = (JE.section_header(f"&#9888; No Janelia Affiliation ({len(review):,})")
+                + f'<div style="color:{JE.GRAY};font-size:12px;margin:-4px 0 10px 0;">'
+                'Matched the Zenodo search but no creator had a Janelia affiliation or a '
+                'known Janelian ORCID - review before ingesting.</div>'
+                + JE.doi_card("No Janelia Affiliation", review, 'warn', icon='&#9888;'))
+        body += JE.body_row(card, '6px 28px 4px 28px')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     try:
         email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
         LOGGER.info(f"Sending email to {email}")
-        opts = {'mime': 'html'}
-        JRC.send_email(msg, DISCONFIG['sender'], email, "Zenodo DOI sync", **opts)
+        JRC.send_email(msg, DISCONFIG['sender'], email, "Zenodo DOI sync", mime='html')
     except Exception as err:
         print(str(err))
         traceback.print_exc()


### PR DESCRIPTION
Convert eight discovery pull programs to send the shared jrc_email house-style run-summary email (navy banner, KPI stat tiles, DOI cards, footer) in place of their plain text_to_html_table + <br> lists. Each program's existing recipient logic (developer for --test, receivers otherwise) is preserved and the mode badge follows the actual recipient; the inline doiurl/text_to_html_table helpers are dropped in favour of jrc_email.

Per program (buckets -> KPI tiles + ready/review cards), with a version bump:
- pull_arxiv.py          1.0.0 -> 1.1.0
- pull_biorxiv.py        1.0.0 -> 1.1.0
- pull_figshare.py       1.0.0 -> 1.1.0  (not-in-DataCite card links to the raw
                                          figshare record via jrc_email's base=)
- pull_openalex.py       2.2.0 -> 2.3.0  (ready/review now link to the DIS doiui
                                          page, consistent with the other pulls,
                                          instead of the OpenAlex-id link)
- pull_openalex_labs.py  6.1.0 -> 6.2.0  (institution-mismatch attachment kept)
- pull_protocolsio.py    1.2.0 -> 1.3.0  (ready/review/alumni/no-Janelian cards)
- pull_springer.py       1.1.0 -> 1.2.0  (adds COUNT['noauthors'] for its tile)
- pull_zenodo.py         1.3.0 -> 1.4.0

Requires jrc_email >= 1.1.0 (the doi_card base= param, used by pull_figshare).

@stuarteberg