### PR TITLE
fix(tags): only auto-apply a Lab tag from an author's own group

### DIFF
--- a/utility/bin/update_tags.py
+++ b/utility/bin/update_tags.py
@@ -2,7 +2,7 @@
     Update tags for selected DOIs
 """
 
-__version__ = '9.1.0'
+__version__ = '9.1.1'
 
 import argparse
 import collections
@@ -180,9 +180,11 @@ def append_tags(auth, janelians, atags):
         if tag in atags:
             continue
         if ARG.AUTO:
-            # A Lab affiliation always applies; any other affiliation only
-            # applies if it's an active supervisory organization
-            if tag.endswith(' Lab') or (tag in current_affiliations and is_active_suporg(tag)):
+            # An affiliation tag auto-applies only if it is a current, active
+            # supervisory organization. A Lab is NOT applied from an author's
+            # affiliation list - a lab is tagged only when an author's own group
+            # is that lab (added above via auth['group']).
+            if tag in current_affiliations and is_active_suporg(tag):
                 atags.append(tag)
         elif tag in DIS['default_tags']:
             atags.append(tag)


### PR DESCRIPTION
The --auto path applied any tag ending in " Lab" from an author's affiliation list (tag.endswith(' Lab')), so a co-author's unrelated lab affiliation was tagged even though no author belonged to it. E.g. DOI 10.64898/2026.07.22.740099 was tagged "Ron Vale Lab" solely because an author lists it as an affiliation.

Drop that clause: a Lab is now tagged only when it is an author's own group (added via auth['group']), so the same DOI tags "Daniel Feliciano Lab" (Daniel Feliciano's group) and no longer "Ron Vale Lab". Non-lab affiliation tags are unchanged (still gated on a current, active supervisory organization). Bumps to 9.1.1.

@stuarteberg