### PR TITLE
refactor(email): migrate Tier-1 sync/bin run-summaries to jrc_email

### DIFF
--- a/sync/bin/add_people_to_orcid.py
+++ b/sync/bin/add_people_to_orcid.py
@@ -12,7 +12,7 @@
     their organization is on the ignore list.
 '''
 
-__version__ = '7.3.2'
+__version__ = '7.3.3'
 
 import argparse
 import collections
@@ -26,6 +26,7 @@ import traceback
 import requests
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,logging-not-lazy
 
@@ -39,21 +40,12 @@ IGNORE = {}
 # People API timeouts that @retry (in jrc_common) exhausts and re-raises
 TIMEOUT = (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout,
            requests.exceptions.Timeout)
-# HTML run-summary email palette (generate_email and its html_* helpers). Mirrors
-# update_janelians_from_people.py/sync_citations.py's email convention: inline
-# styles only (no <style> block/classes) for reliable rendering across email
-# clients including older Outlook.
+# Palette for the retained bespoke email tables (html_metric_rows /
+# html_people_table). The run-summary shell, KPI tiles and section headers now
+# come from jrc_email; inline styles only, for older-Outlook compatibility.
 EMAIL_NAVY = '#1f3a5f'
-EMAIL_GREEN = '#1c7c3f'
-EMAIL_GREEN_BG = '#eefaf1'
-EMAIL_RED = '#c0392b'
-EMAIL_RED_BG = '#fdecea'
-EMAIL_AMBER = '#d68a1f'
-EMAIL_AMBER_BG = '#fdf3e0'
 EMAIL_GRAY = '#5b6b7c'
-EMAIL_GRAY_BG = '#f2f4f6'
 EMAIL_STRIPE_BG = '#f7f9fb'
-EMAIL_BORDER = '#eef1f4'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -312,52 +304,6 @@ def set_alumni(person, orcid, email_entries, orcid_uid):
         terminate_program(err)
 
 
-def html_kpi_card(value, label, tone='neutral'):
-    ''' Build one KPI stat tile for the run-summary email's header row.
-        A single <td> carries the box look directly (bgcolor attribute +
-        background-color, no nested table) - Outlook's Word rendering engine
-        chokes on a percentage-width table nested inside a percentage-width <td>.
-        Keyword arguments:
-          value: display value (already formatted, e.g. "3")
-          label: caption under the value
-          tone: 'neutral', 'good', 'amber', or 'bad' - selects the tile's
-                color scheme
-        Returns:
-          HTML for one table cell
-    '''
-    bg, fg = {'good': (EMAIL_GREEN_BG, EMAIL_GREEN),
-              'bad': (EMAIL_RED_BG, EMAIL_RED),
-              'amber': (EMAIL_AMBER_BG, EMAIL_AMBER),
-              'neutral': (EMAIL_GRAY_BG, EMAIL_GRAY)}[tone]
-    return (f'<td width="25%" align="center" valign="top" bgcolor="{bg}" '
-            f'style="padding:14px 6px;background-color:{bg};border-radius:8px;">'
-            f'<span style="font-size:24px;font-weight:700;color:{fg};'
-            f'line-height:1.2;">{value}</span><br>'
-            f'<span style="font-size:10.5px;color:{EMAIL_GRAY};text-transform:uppercase;'
-            f'letter-spacing:.04em;">{label}</span>'
-            f'</td>')
-
-
-def html_section_header(title):
-    ''' Build a section header bar for the run-summary email. Table-based
-        (not a bare <div>) so it never sits as a naked div immediately before
-        a sibling <table> inside the same <td> - Outlook's Word rendering
-        engine can misparse that div-then-table boundary and leak a stray
-        closing tag as literal visible text. The spacer row substitutes for
-        CSS margin-bottom, which <td> doesn't honor.
-        Keyword arguments:
-          title: section title (may include an HTML entity icon prefix)
-        Returns:
-          HTML table block
-    '''
-    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0">'
-            f'<tr><td style="font-size:14px;font-weight:700;color:{EMAIL_NAVY};'
-            f'border-bottom:2px solid {EMAIL_BORDER};padding-bottom:7px;">'
-            f'{title}</td></tr>'
-            '<tr><td style="height:10px;line-height:10px;font-size:1px;">&nbsp;</td></tr>'
-            '</table>')
-
-
 def html_metric_rows(rows):
     ''' Build a zebra-striped label/value table for the run-summary email.
         Deliberately no per-cell border-radius: Outlook's Word rendering
@@ -366,13 +312,11 @@ def html_metric_rows(rows):
         (confirmed via a real Outlook test - a trailing spacer row alone did
         not fix it), so cells here use only plain background-color striping,
         which Word handles reliably. Also no margin-top on the table itself
-        (html_section_header's trailing spacer row already provides that
-        gap) - confirmed via a real Outlook test that a <table> carrying its
-        own margin-top, sitting immediately after a sibling table's
-        </table>, leaks a stray closing tag as literal visible text. A
-        trailing throwaway spacer row is kept anyway as cheap insurance
-        against the last-row-before-</table> boundary (see
-        html_section_header).
+        (the section header above already provides that gap) - confirmed via a
+        real Outlook test that a <table> carrying its own margin-top, sitting
+        immediately after a sibling table's </table>, leaks a stray closing tag
+        as literal visible text. A trailing throwaway spacer row is kept anyway
+        as cheap insurance against the last-row-before-</table> boundary.
         Keyword arguments:
           rows: list of (label, value_html) pairs
         Returns:
@@ -403,7 +347,7 @@ def html_people_table(entries, empty_message):
         tag as literal visible text in a large, highly-repetitive table like
         this one (Skipped can run to hundreds of rows). A trailing throwaway
         spacer row is kept as cheap insurance against the last-row-before-
-        </table> boundary (see html_section_header).
+        </table> boundary (see html_metric_rows).
         Keyword arguments:
           entries: list of {name, userId, detail} dicts
           empty_message: message to show when entries is empty
@@ -441,9 +385,8 @@ def generate_email(email_entries, new_fname=None):
         Organizations table (org name -> count, sorted by count descending)
         for people skipped due to an ignore-listed organization - listed by
         org rather than by name since that bucket can run to hundreds of
-        people. Built entirely from inline styles/tables (no <style> block)
-        for compatibility with older email clients, matching the convention
-        used by update_janelians_from_people.py and sync_citations.py.
+        people. Rendered in the jrc_email house style; the breakdown and people
+        tables are bespoke (jrc_email has no metric-row or name/detail table).
         Keyword arguments:
           email_entries: {new, boomerang, alumni, skipped} -> list of
                          {name, userId, detail} dicts, and skipped_orgs ->
@@ -454,20 +397,19 @@ def generate_email(email_entries, new_fname=None):
         Returns:
           None
     '''
-    run_data = JRC.get_run_data(__file__, __version__).strip()
-    mode_badge_bg = EMAIL_GREEN if ARG.WRITE else EMAIL_AMBER
+    run_data = (JRC.get_run_data(__file__, __version__).strip()
+                + f" &middot; manifold: {ARG.MANIFOLD}")
     mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
-
+    mode_tone = 'good' if ARG.WRITE else 'warn'
     kpis = ''.join([
-        html_kpi_card(f"{COUNT['people']:,}", "Records read"),
-        html_kpi_card(f"{COUNT['new']:,}", "New employees",
-                      'good' if COUNT['new'] else 'neutral'),
-        html_kpi_card(f"{COUNT['boomerang']:,}", "Boomerangs",
-                      'amber' if COUNT['boomerang'] else 'neutral'),
-        html_kpi_card(f"{COUNT['set_alumni']:,}", "Alumni set",
-                      'amber' if COUNT['set_alumni'] else 'neutral'),
+        JE.kpi_card(f"{COUNT['people']:,}", "Records read", width='25%'),
+        JE.kpi_card(f"{COUNT['new']:,}", "New employees",
+                    'good' if COUNT['new'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['boomerang']:,}", "Boomerangs",
+                    'warn' if COUNT['boomerang'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['set_alumni']:,}", "Alumni set",
+                    'warn' if COUNT['set_alumni'] else 'neutral', '25%'),
     ])
-
     breakdown_rows = [
         ("Already active", f"{COUNT['already_active']:,}"),
         ("Skipped (no People record)", f"{COUNT['skipped_no_record']:,}"),
@@ -482,67 +424,31 @@ def generate_email(email_entries, new_fname=None):
         ("Records inserted", f"{COUNT['insert']:,}"),
         ("Records updated", f"{COUNT['update']:,}"),
     ]
-    breakdown_section = (html_section_header("&#128202; Change Breakdown")
-                         + html_metric_rows(breakdown_rows))
-
-    new_section = (html_section_header(f"&#128100; New Employees "
-                                       f"({len(email_entries['new']):,})")
-                  + html_people_table(email_entries['new'], "No new employees were added."))
-    boomerang_section = (html_section_header(f"&#128257; Boomerangs "
-                                             f"({len(email_entries['boomerang']):,})")
-                        + html_people_table(email_entries['boomerang'], "No boomerangs."))
-    alumni_section = (html_section_header(f"&#127891; Alumni Set "
-                                          f"({len(email_entries['alumni']):,})")
-                      + html_people_table(email_entries['alumni'], "No one was set to alumni."))
-    skipped_section = (html_section_header(f"&#9940; Skipped "
-                                           f"({len(email_entries['skipped']):,})")
-                      + html_people_table(email_entries['skipped'], "Nobody was skipped."))
+    body = JE.body_row(JE.section_header("&#128202; Change Breakdown")
+                       + html_metric_rows(breakdown_rows))
+    body += JE.body_row(
+        JE.section_header(f"&#128100; New Employees ({len(email_entries['new']):,})")
+        + html_people_table(email_entries['new'], "No new employees were added."))
+    body += JE.body_row(
+        JE.section_header(f"&#128257; Boomerangs ({len(email_entries['boomerang']):,})")
+        + html_people_table(email_entries['boomerang'], "No boomerangs."))
+    body += JE.body_row(
+        JE.section_header(f"&#127891; Alumni Set ({len(email_entries['alumni']):,})")
+        + html_people_table(email_entries['alumni'], "No one was set to alumni."))
+    body += JE.body_row(
+        JE.section_header(f"&#9940; Skipped ({len(email_entries['skipped']):,})")
+        + html_people_table(email_entries['skipped'], "Nobody was skipped."))
     ignored_orgs = sorted(email_entries['skipped_orgs'].items(), key=lambda kv: -kv[1])
-    ignored_org_section = (
-        html_section_header(f"&#127970; Ignored Organizations ({len(ignored_orgs):,})")
-        + (html_metric_rows([(html.escape(org), f"{cnt:,}") for org, cnt in ignored_orgs])
-           if ignored_orgs
-           else f'<div style="color:{EMAIL_GRAY};font-size:13px;">'
-                'No organizations were ignored.</div>'))
-
-    msg = (
-        f'<div style="font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;'
-        f'background-color:#eef1f4;padding:8px 0;">'
-        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>'
-        '<td align="center" style="padding:8px 14px 32px 14px;">'
-        '<table role="presentation" width="720" cellpadding="0" cellspacing="0" '
-        'bgcolor="#ffffff" '
-        f'style="max-width:720px;width:100%;background-color:#ffffff;border-radius:10px;'
-        f'border:1px solid {EMAIL_BORDER};overflow:hidden;">'
-        f'<tr><td bgcolor="{EMAIL_NAVY}" style="background-color:{EMAIL_NAVY};'
-        f'padding:22px 28px;">'
-        f'<div style="color:#ffffff;font-size:19px;font-weight:600;">'
-        f'{os.path.basename(__file__)}&nbsp;'
-        f'<span style="font-weight:400;opacity:.7;font-size:14px;">v{__version__}</span></div>'
-        f'<div style="color:#c9d6e6;font-size:12.5px;margin-top:6px;">{run_data} &middot; '
-        f'manifold: {ARG.MANIFOLD} &middot; '
-        f'<span style="background-color:{mode_badge_bg};color:#fff;border-radius:10px;'
-        f'padding:1px 9px;font-size:11px;font-weight:600;letter-spacing:.03em;">'
-        f'{mode_label}</span></div></td></tr>'
-        f'<tr><td style="padding:22px 22px 6px 22px;">'
-        # cellspacing (not CSS margin, which <td> mostly ignores) puts a real gap
-        # between the KPI tiles; Outlook's Word engine honors this old-school
-        # HTML attribute far more reliably than CSS spacing tricks.
-        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="6"><tr>'
-        f'{kpis}</tr></table></td></tr>'
-        f'<tr><td style="padding:18px 28px 4px 28px;">{breakdown_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{new_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{boomerang_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{alumni_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{skipped_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{ignored_org_section}</td></tr>'
-        f'<tr><td bgcolor="{EMAIL_STRIPE_BG}" style="padding:18px 28px;'
-        f'background-color:{EMAIL_STRIPE_BG};color:{EMAIL_GRAY};'
-        f'font-size:11px;text-align:center;border-top:1px solid {EMAIL_BORDER};">'
-        'Generated by add_people_to_orcid.py &middot; Data and Information Services '
-        '&middot; Janelia Research Campus</td></tr>'
-        '</table></td></tr></table></div>')
-
+    ignored_html = (
+        html_metric_rows([(html.escape(org), f"{cnt:,}") for org, cnt in ignored_orgs])
+        if ignored_orgs
+        else f'<div style="color:{EMAIL_GRAY};font-size:13px;">'
+             'No organizations were ignored.</div>')
+    body += JE.body_row(
+        JE.section_header(f"&#127970; Ignored Organizations ({len(ignored_orgs):,})")
+        + ignored_html)
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     subject = "Janelians added to orcid collection from People system"
     email = DIS['developer'] if ARG.TEST else DIS['receivers']
     try:

--- a/sync/bin/apply_orcids.py
+++ b/sync/bin/apply_orcids.py
@@ -10,7 +10,7 @@
     linked to orcid.org).
 '''
 
-__version__ = '2.1.2'
+__version__ = '2.1.3'
 
 import argparse
 import collections
@@ -27,6 +27,7 @@ import requests
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation
 
@@ -51,20 +52,13 @@ TIMEOUT = (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout,
 ADDED = []
 OUTPUT = {"name_error": [], "name_multi_records": [], "name_not_found": [], "orcid_exists": [],
           "orcid_mismatch": [], "orcid_added": []}
-# HTML run-summary email palette (generate_email and its html_* helpers). Mirrors
-# the sibling sync scripts: inline styles only (no <style> block/classes) for
-# reliable rendering across email clients including older Outlook.
+# Palette for the bespoke email tables (html_metric_rows, html_added_table) that
+# jrc_email does not cover; the run-summary shell, KPI tiles and section headers
+# now come from jrc_email. Inline styles only, for reliable rendering in older
+# Outlook.
 EMAIL_NAVY = '#1f3a5f'
-EMAIL_GREEN = '#1c7c3f'
-EMAIL_GREEN_BG = '#eefaf1'
-EMAIL_RED = '#c0392b'
-EMAIL_RED_BG = '#fdecea'
-EMAIL_AMBER = '#d68a1f'
-EMAIL_AMBER_BG = '#fdf3e0'
 EMAIL_GRAY = '#5b6b7c'
-EMAIL_GRAY_BG = '#f2f4f6'
 EMAIL_STRIPE_BG = '#f7f9fb'
-EMAIL_BORDER = '#eef1f4'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -314,61 +308,17 @@ def process_orcid(oid):
     check_orcid(oid, name, family, given)
 
 
-def html_kpi_card(value, label, tone='neutral'):
-    ''' Build one KPI stat tile for the run-summary email's header row. A single
-        <td> carries the box look directly (bgcolor + background-color, no nested
-        table) - Outlook's Word engine chokes on a percentage-width table nested
-        in a percentage-width <td>.
-        Keyword arguments:
-          value: display value (already formatted)
-          label: caption under the value
-          tone: 'neutral', 'good', 'amber', or 'bad' - selects the color scheme
-        Returns:
-          HTML for one table cell
-    '''
-    bg, fg = {'good': (EMAIL_GREEN_BG, EMAIL_GREEN),
-              'bad': (EMAIL_RED_BG, EMAIL_RED),
-              'amber': (EMAIL_AMBER_BG, EMAIL_AMBER),
-              'neutral': (EMAIL_GRAY_BG, EMAIL_GRAY)}[tone]
-    return (f'<td width="25%" align="center" valign="top" bgcolor="{bg}" '
-            f'style="padding:14px 6px;background-color:{bg};border-radius:8px;">'
-            f'<span style="font-size:24px;font-weight:700;color:{fg};'
-            f'line-height:1.2;">{value}</span><br>'
-            f'<span style="font-size:10.5px;color:{EMAIL_GRAY};text-transform:uppercase;'
-            f'letter-spacing:.04em;">{label}</span>'
-            f'</td>')
-
-
-def html_section_header(title):
-    ''' Build a section header bar. Table-based (not a bare <div>) so it never
-        sits as a naked div immediately before a sibling <table> in the same
-        <td> - Outlook's Word engine can misparse that boundary and leak a stray
-        closing tag as literal text. The spacer row substitutes for CSS
-        margin-bottom, which <td> doesn't honor.
-        Keyword arguments:
-          title: section title (may include an HTML entity icon prefix)
-        Returns:
-          HTML table block
-    '''
-    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0">'
-            f'<tr><td style="font-size:14px;font-weight:700;color:{EMAIL_NAVY};'
-            f'border-bottom:2px solid {EMAIL_BORDER};padding-bottom:7px;">'
-            f'{title}</td></tr>'
-            '<tr><td style="height:10px;line-height:10px;font-size:1px;">&nbsp;</td></tr>'
-            '</table>')
-
-
 def html_metric_rows(rows):
     ''' Build a zebra-striped label/value table. No per-cell border-radius:
         Outlook's Word engine can leak a cell's opening tag as literal text in
         tables that repeat the same complex inline style across many rows, so
         cells use only plain background-color striping. Also no margin-top on
-        the table itself (html_section_header's trailing spacer row already
-        provides that gap) - confirmed via a real Outlook test that a <table>
-        carrying its own margin-top, sitting immediately after a sibling
-        table's </table>, leaks a stray closing tag as literal visible text.
-        A trailing spacer row absorbs the last-row-before-</table> boundary
-        (see html_section_header).
+        the table itself (the jrc_email section header above already provides
+        that gap via its margin-bottom) - confirmed via a real Outlook test that
+        a <table> carrying its own margin-top, sitting immediately after a
+        sibling table's </table>, leaks a stray closing tag as literal visible
+        text. A trailing spacer row absorbs the last-row-before-</table>
+        boundary.
         Keyword arguments:
           rows: list of (label, value) pairs
         Returns:
@@ -434,15 +384,16 @@ def generate_email(dois, fname):
           None
     '''
     run_data = JRC.get_run_data(__file__, __version__).strip()
-    mode_badge_bg = EMAIL_GREEN if ARG.WRITE else EMAIL_AMBER
+    run_data += f" &middot; institution: {ARG.INSTITUTION} &middot; manifold: {ARG.MANIFOLD}"
     mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
     kpis = ''.join([
-        html_kpi_card(f"{COUNT['read']:,}", "ORCIDs read"),
-        html_kpi_card(f"{COUNT['considered']:,}", "Considered"),
-        html_kpi_card(f"{len(OUTPUT['orcid_added']):,}", "Added",
-                      'good' if OUTPUT['orcid_added'] else 'neutral'),
-        html_kpi_card(f"{len(OUTPUT['orcid_mismatch']):,}", "Mismatches",
-                      'amber' if OUTPUT['orcid_mismatch'] else 'neutral'),
+        JE.kpi_card(f"{COUNT['read']:,}", "ORCIDs read", width='25%'),
+        JE.kpi_card(f"{COUNT['considered']:,}", "Considered", width='25%'),
+        JE.kpi_card(f"{len(OUTPUT['orcid_added']):,}", "Added",
+                    'good' if OUTPUT['orcid_added'] else 'neutral', '25%'),
+        JE.kpi_card(f"{len(OUTPUT['orcid_mismatch']):,}", "Mismatches",
+                    'warn' if OUTPUT['orcid_mismatch'] else 'neutral', '25%'),
     ])
     breakdown_rows = [
         ("Already have ORCID", f"{len(OUTPUT['orcid_exists']):,}"),
@@ -456,38 +407,14 @@ def generate_email(dois, fname):
     ]
     if dois:
         breakdown_rows.append(("DOIs to update", f"{len(dois):,}"))
-    breakdown_section = (html_section_header("&#128202; Change Breakdown")
-                         + html_metric_rows(breakdown_rows))
-    added_section = (html_section_header(f"&#9989; ORCIDs Added ({len(ADDED):,})")
-                     + html_added_table(ADDED))
-    msg = (
-        f'<div style="font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;'
-        f'background-color:#eef1f4;padding:8px 0;">'
-        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>'
-        '<td align="center" style="padding:8px 14px 32px 14px;">'
-        '<table role="presentation" width="720" cellpadding="0" cellspacing="0" bgcolor="#ffffff" '
-        f'style="max-width:720px;width:100%;background-color:#ffffff;border-radius:10px;'
-        f'border:1px solid {EMAIL_BORDER};overflow:hidden;">'
-        f'<tr><td bgcolor="{EMAIL_NAVY}" style="background-color:{EMAIL_NAVY};padding:22px 28px;">'
-        f'<div style="color:#ffffff;font-size:19px;font-weight:600;">'
-        f'{os.path.basename(__file__)}&nbsp;'
-        f'<span style="font-weight:400;opacity:.7;font-size:14px;">v{__version__}</span></div>'
-        f'<div style="color:#c9d6e6;font-size:12.5px;margin-top:6px;">{run_data} &middot; '
-        f'institution: {ARG.INSTITUTION} &middot; manifold: {ARG.MANIFOLD} &middot; '
-        f'<span style="background-color:{mode_badge_bg};color:#fff;border-radius:10px;'
-        f'padding:1px 9px;font-size:11px;font-weight:600;letter-spacing:.03em;">'
-        f'{mode_label}</span></div></td></tr>'
-        f'<tr><td style="padding:22px 22px 6px 22px;">'
-        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="6"><tr>'
-        f'{kpis}</tr></table></td></tr>'
-        f'<tr><td style="padding:18px 28px 4px 28px;">{breakdown_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{added_section}</td></tr>'
-        f'<tr><td bgcolor="{EMAIL_STRIPE_BG}" style="padding:18px 28px;'
-        f'background-color:{EMAIL_STRIPE_BG};color:{EMAIL_GRAY};'
-        f'font-size:11px;text-align:center;border-top:1px solid {EMAIL_BORDER};">'
-        'Generated by apply_orcids.py &middot; Data and Information Services '
-        '&middot; Janelia Research Campus</td></tr>'
-        '</table></td></tr></table></div>')
+    # Bespoke tables (metric rows, Author/ORCID list) that jrc_email doesn't
+    # cover, wrapped in jrc_email section headers + body rows.
+    body = JE.body_row(JE.section_header("&#128202; Change Breakdown")
+                       + html_metric_rows(breakdown_rows))
+    body += JE.body_row(JE.section_header(f"&#9989; ORCIDs Added ({len(ADDED):,})")
+                        + html_added_table(ADDED))
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     subject = "ORCIDs added to orcid collection"
     email = DIS['developer'] if ARG.TEST else DIS['receivers']
     attach = fname if (dois and os.path.exists(fname)) else None

--- a/sync/bin/sync_citations.py
+++ b/sync/bin/sync_citations.py
@@ -181,7 +181,7 @@
         (falling back to the native citationCount).
 '''
 
-__version__ = '1.12.1'
+__version__ = '1.12.2'
 
 import argparse
 import collections
@@ -200,6 +200,7 @@ from pymongo.errors import BulkWriteError
 import requests
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,logging-fstring-interpolation
 
@@ -388,7 +389,6 @@ EMAIL_GREEN = '#1c7c3f'
 EMAIL_GREEN_BG = '#eefaf1'
 EMAIL_RED = '#c0392b'
 EMAIL_RED_BG = '#fdecea'
-EMAIL_AMBER = '#d68a1f'
 EMAIL_GRAY = '#5b6b7c'
 EMAIL_GRAY_BG = '#f2f4f6'
 EMAIL_STRIPE_BG = '#f7f9fb'
@@ -1371,32 +1371,6 @@ def doiurl(doi):
             f"style='color:{EMAIL_BLUE};text-decoration:none;'>{doi}</a>")
 
 
-def html_kpi_card(value, label, tone='neutral'):
-    ''' Build one KPI stat tile for the run-summary email's header row.
-        A single <td> carries the box look directly (bgcolor attribute +
-        background-color, no nested table) - Outlook's Word rendering engine
-        chokes on a percentage-width table nested inside a percentage-width
-        <td> (this one used to nest a width="100%" table inside width="25%"),
-        sometimes dumping raw markup as visible text instead of rendering it.
-        Keyword arguments:
-          value: display value (already formatted, e.g. "52" or "33/0")
-          label: caption under the value
-          tone: 'neutral', 'good', or 'bad' - selects the tile's color scheme
-        Returns:
-          HTML for one table cell
-    '''
-    bg, fg = {'good': (EMAIL_GREEN_BG, EMAIL_GREEN),
-              'bad': (EMAIL_RED_BG, EMAIL_RED),
-              'neutral': (EMAIL_GRAY_BG, EMAIL_GRAY)}[tone]
-    return (f'<td width="25%" align="center" valign="top" bgcolor="{bg}" '
-            f'style="padding:14px 6px;background-color:{bg};border-radius:8px;">'
-            f'<span style="font-size:24px;font-weight:700;color:{fg};'
-            f'line-height:1.2;">{value}</span><br>'
-            f'<span style="font-size:10.5px;color:{EMAIL_GRAY};text-transform:uppercase;'
-            f'letter-spacing:.04em;">{label}</span>'
-            f'</td>')
-
-
 def html_section_header(title):
     ''' Build a section header bar. Table-based (not a bare <div>) so it never
         sits as a naked div immediately before a sibling <table> in the same
@@ -1476,8 +1450,8 @@ def html_pill(bg, fg, text, align=None):
     ''' Build a small colored status badge as an auto-width single-cell table
         (bgcolor attribute + background-color CSS), not a <span> - Outlook's
         Word engine does not honor background-color on inline elements, and
-        <span> has no bgcolor attribute to fall back on (see html_kpi_card for
-        the same issue on block elements). Only safe where the badge is the
+        <span> has no bgcolor attribute to fall back on (the same issue affects
+        block elements). Only safe where the badge is the
         sole content of its table cell: an auto-width table still renders as a
         block, so it cannot sit inline mid-sentence next to other text.
         Keyword arguments:
@@ -1529,9 +1503,8 @@ def html_usage_card(label, ok, err, attrs, prefix):
              '<td style="padding:6px 4px;" align="right">Changed</td><td></td></tr>'
              + "".join(rows) + '</table>')
     # Header row is two <td>s directly in the outer table (not a nested
-    # width="100%" table inside one <td>) - see html_kpi_card for why: Outlook's
-    # Word engine chokes on that nesting. The body row below spans both with
-    # colspan="2".
+    # width="100%" table inside one <td>) - Outlook's Word engine chokes on that
+    # nesting. The body row below spans both with colspan="2".
     return (
         '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
         f'style="border:1px solid {EMAIL_BORDER};border-radius:8px;margin-bottom:14px;'
@@ -1628,17 +1601,18 @@ def generate_email():  # pylint: disable=too-many-locals
     label = PUBLISHERS[ARG.PUBLISHER]['label'] if ARG.PUBLISHER else SOURCES[ARG.SOURCE]['label']
     restrict = f' (--publisher {ARG.PUBLISHER})' if ARG.PUBLISHER else ''
     run_data = JRC.get_run_data(__file__, __version__).strip()
-    mode_badge_bg = EMAIL_GREEN if ARG.WRITE else EMAIL_AMBER
+    run_data = f"{run_data} &middot; {label} mode{restrict} &middot; manifold: {ARG.MANIFOLD}"
     mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
 
     kpis = ''.join([
-        html_kpi_card(f"{COUNT['read']:,}", f"{label} DOIs processed"),
-        html_kpi_card(f"{COUNT['openalex_found']:,}/{COUNT['openalex_error']:,}",
-                      "OpenAlex OK/err", 'bad' if COUNT['openalex_error'] else 'good'),
-        html_kpi_card(f"{COUNT['scholex_found']:,}/{COUNT['scholex_error']:,}",
-                      "ScholeXplorer OK/err", 'bad' if COUNT['scholex_error'] else 'good'),
-        html_kpi_card(f"{COUNT['fetch_error']:,}", "Fetch errors",
-                      'bad' if COUNT['fetch_error'] else 'neutral'),
+        JE.kpi_card(f"{COUNT['read']:,}", f"{label} DOIs processed", width='25%'),
+        JE.kpi_card(f"{COUNT['openalex_found']:,}/{COUNT['openalex_error']:,}",
+                    "OpenAlex OK/err", 'bad' if COUNT['openalex_error'] else 'good', '25%'),
+        JE.kpi_card(f"{COUNT['scholex_found']:,}/{COUNT['scholex_error']:,}",
+                    "ScholeXplorer OK/err", 'bad' if COUNT['scholex_error'] else 'good', '25%'),
+        JE.kpi_card(f"{COUNT['fetch_error']:,}", "Fetch errors",
+                    'bad' if COUNT['fetch_error'] else 'neutral', '25%'),
     ])
 
     citation_rows = [("OpenAlex unchanged (skipped)", f"{COUNT['openalex_unchanged']:,}"),
@@ -1681,40 +1655,11 @@ def generate_email():  # pylint: disable=too-many-locals
     hits_section = (html_section_header(f"&#11014; Citation Increases ({len(HITS):,})")
                     + html_citation_increases())
 
-    msg = (
-        f'<div style="font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;'
-        f'background-color:#eef1f4;padding:8px 0;">'
-        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>'
-        '<td align="center" style="padding:8px 14px 32px 14px;">'
-        '<table role="presentation" width="720" cellpadding="0" cellspacing="0" '
-        'bgcolor="#ffffff" '
-        f'style="max-width:720px;width:100%;background-color:#ffffff;border-radius:10px;'
-        f'border:1px solid {EMAIL_BORDER};overflow:hidden;">'
-        f'<tr><td bgcolor="{EMAIL_NAVY}" style="background-color:{EMAIL_NAVY};'
-        f'padding:22px 28px;">'
-        f'<div style="color:#ffffff;font-size:19px;font-weight:600;">'
-        f'{os.path.basename(__file__)}&nbsp;'
-        f'<span style="font-weight:400;opacity:.7;font-size:14px;">v{__version__}</span></div>'
-        f'<div style="color:#c9d6e6;font-size:12.5px;margin-top:6px;">{run_data} &middot; '
-        f'{label} mode{restrict} &middot; '
-        f'<span style="background-color:{mode_badge_bg};color:#fff;border-radius:10px;'
-        f'padding:1px 9px;font-size:11px;font-weight:600;letter-spacing:.03em;">'
-        f'{mode_label}</span> &middot; manifold: {ARG.MANIFOLD}</div></td></tr>'
-        f'<tr><td style="padding:22px 22px 6px 22px;">'
-        # cellspacing (not CSS margin, which <td> mostly ignores) puts a real gap
-        # between the KPI tiles; Outlook's Word engine honors this old-school
-        # HTML attribute far more reliably than CSS spacing tricks.
-        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="6"><tr>'
-        f'{kpis}</tr></table></td></tr>'
-        f'<tr><td style="padding:18px 28px 4px 28px;">{citation_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{usage_section}</td></tr>'
-        f'<tr><td style="padding:16px 28px 6px 28px;">{hits_section}</td></tr>'
-        f'<tr><td bgcolor="{EMAIL_STRIPE_BG}" style="padding:18px 28px;'
-        f'background-color:{EMAIL_STRIPE_BG};color:{EMAIL_GRAY};'
-        f'font-size:11px;text-align:center;border-top:1px solid {EMAIL_BORDER};">'
-        'Generated by sync_citations.py &middot; Data and Information Services &middot; '
-        'Janelia Research Campus</td></tr>'
-        '</table></td></tr></table></div>')
+    body = (JE.body_row(citation_section, '18px 28px 4px 28px')
+            + JE.body_row(usage_section, '20px 28px 4px 28px')
+            + JE.body_row(hits_section, '16px 28px 6px 28px'))
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
 
     try:
         if ARG.TEST:

--- a/sync/bin/sync_openalex.py
+++ b/sync/bin/sync_openalex.py
@@ -16,7 +16,7 @@
     with sync_openalex.json attached.
 """
 
-__version__ = '4.2.1'
+__version__ = '4.2.2'
 
 import argparse
 import collections
@@ -31,6 +31,7 @@ import traceback
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 import dis_license_lib as DISL
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,logging-not-lazy,duplicate-code
@@ -44,20 +45,9 @@ COUNT = collections.defaultdict(lambda: 0, {})
 # Unique raw license strings that couldn't be mapped ("Unknown ... license"),
 # excluding bare URLs (http/https...), for triage - shown in the console and email.
 UNKNOWN_LICENSES = set()
-# HTML run-summary email palette (generate_email and its html_* helpers). Mirrors
-# the sibling sync scripts: inline styles only (no <style> block/classes) for
-# reliable rendering across email clients including older Outlook.
-EMAIL_NAVY = '#1f3a5f'
-EMAIL_GREEN = '#1c7c3f'
-EMAIL_GREEN_BG = '#eefaf1'
-EMAIL_RED = '#c0392b'
-EMAIL_RED_BG = '#fdecea'
-EMAIL_AMBER = '#d68a1f'
-EMAIL_AMBER_BG = '#fdf3e0'
-EMAIL_GRAY = '#5b6b7c'
-EMAIL_GRAY_BG = '#f2f4f6'
+# Row-striping color for the metric/license tables (the only inline email helpers
+# retained; the banner/KPI/section shell now comes from jrc_email).
 EMAIL_STRIPE_BG = '#f7f9fb'
-EMAIL_BORDER = '#eef1f4'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -294,56 +284,12 @@ def show_counts():
     return msg
 
 
-def html_kpi_card(value, label, tone='neutral'):
-    ''' Build one KPI stat tile for the run-summary email's header row. A single
-        <td> carries the box look directly (bgcolor + background-color, no nested
-        table) - Outlook's Word engine chokes on a percentage-width table nested
-        in a percentage-width <td>.
-        Keyword arguments:
-          value: display value (already formatted)
-          label: caption under the value
-          tone: 'neutral', 'good', 'amber', or 'bad' - selects the color scheme
-        Returns:
-          HTML for one table cell
-    '''
-    bg, fg = {'good': (EMAIL_GREEN_BG, EMAIL_GREEN),
-              'bad': (EMAIL_RED_BG, EMAIL_RED),
-              'amber': (EMAIL_AMBER_BG, EMAIL_AMBER),
-              'neutral': (EMAIL_GRAY_BG, EMAIL_GRAY)}[tone]
-    return (f'<td width="25%" align="center" valign="top" bgcolor="{bg}" '
-            f'style="padding:14px 6px;background-color:{bg};border-radius:8px;">'
-            f'<span style="font-size:24px;font-weight:700;color:{fg};'
-            f'line-height:1.2;">{value}</span><br>'
-            f'<span style="font-size:10.5px;color:{EMAIL_GRAY};text-transform:uppercase;'
-            f'letter-spacing:.04em;">{label}</span>'
-            f'</td>')
-
-
-def html_section_header(title):
-    ''' Build a section header bar. Table-based (not a bare <div>) so it never
-        sits as a naked div immediately before a sibling <table> in the same <td>
-        - Outlook's Word engine can misparse that boundary and leak a stray
-        closing tag as literal text. The spacer row substitutes for CSS
-        margin-bottom, which <td> doesn't honor.
-        Keyword arguments:
-          title: section title (may include an HTML entity icon prefix)
-        Returns:
-          HTML table block
-    '''
-    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0">'
-            f'<tr><td style="font-size:14px;font-weight:700;color:{EMAIL_NAVY};'
-            f'border-bottom:2px solid {EMAIL_BORDER};padding-bottom:7px;">'
-            f'{title}</td></tr>'
-            '<tr><td style="height:10px;line-height:10px;font-size:1px;">&nbsp;</td></tr>'
-            '</table>')
-
-
 def html_metric_rows(rows):
     ''' Build a zebra-striped label/value table. No per-cell border-radius:
         Outlook's Word engine can leak a cell's opening tag as literal text in
         tables repeating the same complex inline style across many rows, so cells
         use plain background-color striping. A trailing spacer row absorbs the
-        last-row-before-</table> boundary (see html_section_header).
+        last-row-before-</table> boundary.
         Keyword arguments:
           rows: list of (label, value) pairs
         Returns:
@@ -384,12 +330,11 @@ def html_license_list(licenses):
 
 
 def generate_email(pass1, pass2, unknown_licenses):
-    ''' Generate and send the HTML run-summary email: a header banner (run data,
-        DRY RUN/WRITE badge), KPI stat tiles, two Change Breakdown tables (one
-        for the OA/license pass and one for the OA-status-override pass), and -
-        when any were found - an Unmapped Licenses list. Built entirely from
-        inline styles/tables (no <style> block) for compatibility with older
-        email clients, matching the sibling sync scripts.
+    ''' Generate and send the HTML run-summary email (jrc_email house style): a
+        header banner (run data, manifold/restrict, DRY RUN/WRITE badge), KPI stat
+        tiles, two Change Breakdown tables (OA/license and OA-status-override), and
+        - when any were found - an Unmapped Licenses list. The metric and license
+        tables are kept as inline helpers (jrc_email has no equivalent for them).
         Keyword arguments:
           pass1: counts snapshot from the OA/license pass
           pass2: counts snapshot from the OA-status-override pass
@@ -398,8 +343,6 @@ def generate_email(pass1, pass2, unknown_licenses):
           None
     '''
     run_data = JRC.get_run_data(__file__, __version__).strip()
-    mode_badge_bg = EMAIL_GREEN if ARG.WRITE else EMAIL_AMBER
-    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
     if ARG.DOI:
         restrict = f' &middot; doi: {ARG.DOI}'
     elif ARG.FILE:
@@ -408,14 +351,17 @@ def generate_email(pass1, pass2, unknown_licenses):
         restrict = ' &middot; --new'
     else:
         restrict = ''
+    run_data = f"{run_data} &middot; manifold: {ARG.MANIFOLD}{restrict}"
+    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
     kpis = ''.join([
-        html_kpi_card(f"{pass1.get('dois', 0):,}", "DOIs read"),
-        html_kpi_card(f"{pass1.get('updated', 0):,}", "OA/license set",
-                      'good' if pass1.get('updated') else 'neutral'),
-        html_kpi_card(f"{pass2.get('updated', 0):,}", "OA overrides",
-                      'good' if pass2.get('updated') else 'neutral'),
-        html_kpi_card(f"{pass1.get('notfound', 0):,}", "Not in OpenAlex",
-                      'amber' if pass1.get('notfound') else 'neutral'),
+        JE.kpi_card(f"{pass1.get('dois', 0):,}", "DOIs read", width='25%'),
+        JE.kpi_card(f"{pass1.get('updated', 0):,}", "OA/license set",
+                    'good' if pass1.get('updated') else 'neutral', '25%'),
+        JE.kpi_card(f"{pass2.get('updated', 0):,}", "OA overrides",
+                    'good' if pass2.get('updated') else 'neutral', '25%'),
+        JE.kpi_card(f"{pass1.get('notfound', 0):,}", "Not in OpenAlex",
+                    'warn' if pass1.get('notfound') else 'neutral', '25%'),
     ])
     oa_rows = [
         ("DOIs read", f"{pass1.get('dois', 0):,}"),
@@ -433,46 +379,16 @@ def generate_email(pass1, pass2, unknown_licenses):
         ("DOIs read", f"{pass2.get('dois', 0):,}"),
         ("Closed &rarr; hybrid overrides", f"{pass2.get('updated', 0):,}"),
     ]
-    oa_section = (html_section_header("&#128220; Open Access / License")
-                  + html_metric_rows(oa_rows))
-    override_section = (html_section_header("&#128260; OA Status Override")
+    body = JE.body_row(JE.section_header("&#128220; Open Access / License")
+                       + html_metric_rows(oa_rows))
+    body += JE.body_row(JE.section_header("&#128260; OA Status Override")
                         + html_metric_rows(override_rows))
-    unknown_block = ''
     if unknown_licenses:
-        unknown_block = (
-            '<tr><td style="padding:20px 28px 4px 28px;">'
-            + html_section_header(f"&#10067; Unmapped Licenses ({len(unknown_licenses):,})")
-            + html_license_list(unknown_licenses)
-            + '</td></tr>')
-    msg = (
-        f'<div style="font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;'
-        f'background-color:#eef1f4;padding:8px 0;">'
-        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>'
-        '<td align="center" style="padding:8px 14px 32px 14px;">'
-        '<table role="presentation" width="720" cellpadding="0" cellspacing="0" bgcolor="#ffffff" '
-        f'style="max-width:720px;width:100%;background-color:#ffffff;border-radius:10px;'
-        f'border:1px solid {EMAIL_BORDER};overflow:hidden;">'
-        f'<tr><td bgcolor="{EMAIL_NAVY}" style="background-color:{EMAIL_NAVY};padding:22px 28px;">'
-        f'<div style="color:#ffffff;font-size:19px;font-weight:600;">'
-        f'{os.path.basename(__file__)}&nbsp;'
-        f'<span style="font-weight:400;opacity:.7;font-size:14px;">v{__version__}</span></div>'
-        f'<div style="color:#c9d6e6;font-size:12.5px;margin-top:6px;">{run_data} &middot; '
-        f'manifold: {ARG.MANIFOLD}{restrict} &middot; '
-        f'<span style="background-color:{mode_badge_bg};color:#fff;border-radius:10px;'
-        f'padding:1px 9px;font-size:11px;font-weight:600;letter-spacing:.03em;">'
-        f'{mode_label}</span></div></td></tr>'
-        f'<tr><td style="padding:22px 22px 6px 22px;">'
-        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="6"><tr>'
-        f'{kpis}</tr></table></td></tr>'
-        f'<tr><td style="padding:18px 28px 4px 28px;">{oa_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{override_section}</td></tr>'
-        f'{unknown_block}'
-        f'<tr><td bgcolor="{EMAIL_STRIPE_BG}" style="padding:18px 28px;'
-        f'background-color:{EMAIL_STRIPE_BG};color:{EMAIL_GRAY};'
-        f'font-size:11px;text-align:center;border-top:1px solid {EMAIL_BORDER};">'
-        'Generated by sync_openalex.py &middot; Data and Information Services '
-        '&middot; Janelia Research Campus</td></tr>'
-        '</table></td></tr></table></div>')
+        body += JE.body_row(
+            JE.section_header(f"&#10067; Unmapped Licenses ({len(unknown_licenses):,})")
+            + html_license_list(unknown_licenses))
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     subject = "OpenAlex OA/license sync"
     email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
     attach = 'sync_openalex.json' if os.path.exists('sync_openalex.json') else None

--- a/sync/bin/update_janelians_from_people.py
+++ b/sync/bin/update_janelians_from_people.py
@@ -36,7 +36,7 @@ With Changes table listing every updated author (linked to their /userui/
 record) with a plain-English diff of exactly what changed on their record.
 """
 
-__version__ = '6.3.2'
+__version__ = '6.3.3'
 
 import argparse
 import collections
@@ -50,6 +50,7 @@ import traceback
 import requests
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,logging-not-lazy
 
@@ -62,21 +63,11 @@ ARG = DIS = LOGGER = None
 IGNORE = {}
 TIMEOUT = (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout,
            requests.exceptions.Timeout)
-# HTML run-summary email palette (generate_email and its html_* helpers). Mirrors
-# sync_citations.py/tag_janelia_acks.py's email convention: inline styles only (no
-# <style> block/classes) for reliable rendering across email clients including
-# older Outlook.
+# Palette for the bespoke run-summary email tables (html_metric_rows and
+# html_changes_table); the banner/KPI/section-header shell comes from jrc_email.
 EMAIL_NAVY = '#1f3a5f'
-EMAIL_GREEN = '#1c7c3f'
-EMAIL_GREEN_BG = '#eefaf1'
-EMAIL_RED = '#c0392b'
-EMAIL_RED_BG = '#fdecea'
-EMAIL_AMBER = '#d68a1f'
-EMAIL_AMBER_BG = '#fdf3e0'
 EMAIL_GRAY = '#5b6b7c'
-EMAIL_GRAY_BG = '#f2f4f6'
 EMAIL_STRIPE_BG = '#f7f9fb'
-EMAIL_BORDER = '#eef1f4'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -418,57 +409,9 @@ def record_updates(idresp, row):
     return dirty
 
 
-def html_kpi_card(value, label, tone='neutral'):
-    ''' Build one KPI stat tile for the run-summary email's header row.
-        A single <td> carries the box look directly (bgcolor attribute +
-        background-color, no nested table) - Outlook's Word rendering engine
-        chokes on a percentage-width table nested inside a percentage-width <td>.
-        Keyword arguments:
-          value: display value (already formatted, e.g. "3")
-          label: caption under the value
-          tone: 'neutral', 'good', 'amber', or 'bad' - selects the tile's
-                color scheme
-        Returns:
-          HTML for one table cell
-    '''
-    bg, fg = {'good': (EMAIL_GREEN_BG, EMAIL_GREEN),
-              'bad': (EMAIL_RED_BG, EMAIL_RED),
-              'amber': (EMAIL_AMBER_BG, EMAIL_AMBER),
-              'neutral': (EMAIL_GRAY_BG, EMAIL_GRAY)}[tone]
-    return (f'<td width="25%" align="center" valign="top" bgcolor="{bg}" '
-            f'style="padding:14px 6px;background-color:{bg};border-radius:8px;">'
-            f'<span style="font-size:24px;font-weight:700;color:{fg};'
-            f'line-height:1.2;">{value}</span><br>'
-            f'<span style="font-size:10.5px;color:{EMAIL_GRAY};text-transform:uppercase;'
-            f'letter-spacing:.04em;">{label}</span>'
-            f'</td>')
-
-
-def html_section_header(title):
-    ''' Build a section header bar for the run-summary email. Table-based
-        (not a bare <div>) so it never sits as a naked div immediately before
-        a sibling <table> inside the same <td> - Outlook's Word rendering
-        engine can misparse that div-then-table boundary and leak a stray
-        closing tag as literal visible text (only masked when the sibling
-        content happens to be a <div> too, e.g. an empty-state message
-        instead of a real table).  The spacer row substitutes for CSS
-        margin-bottom, which <td> doesn't honor.
-        Keyword arguments:
-          title: section title (may include an HTML entity icon prefix)
-        Returns:
-          HTML table block
-    '''
-    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0">'
-            f'<tr><td style="font-size:14px;font-weight:700;color:{EMAIL_NAVY};'
-            f'border-bottom:2px solid {EMAIL_BORDER};padding-bottom:7px;">'
-            f'{title}</td></tr>'
-            '<tr><td style="height:10px;line-height:10px;font-size:1px;">&nbsp;</td></tr>'
-            '</table>')
-
-
 def html_metric_rows(rows):
     ''' Build a zebra-striped label/value table for the run-summary email.
-        No margin-top on the table itself (html_section_header's trailing
+        No margin-top on the table itself (the section header's trailing
         spacer row already provides that gap) - confirmed via a real Outlook
         test that a <table> carrying its own margin-top, sitting immediately
         after a sibling table's </table>, leaks a stray closing tag as
@@ -537,29 +480,27 @@ def html_changes_table(changes_log):
 def generate_email(changes_log):
     ''' Generate and send the HTML run-summary email: a header banner (run
         data, DRY RUN/WRITE badge), KPI stat tiles, a change-type breakdown,
-        and the Authors with changes table. Built entirely from inline
-        styles/tables (no <style> block) for compatibility with older email
-        clients, matching the convention used by sync_citations.py and the
-        acknowledgement sync scripts.
+        and the Authors with changes table. The banner/KPI/section-header shell
+        is built with the shared jrc_email library; the Change Breakdown and
+        Authors-with-changes tables remain bespoke inline helpers.
         Keyword arguments:
           changes_log: list of {name, userId, changes} dicts from update_orcid()
         Returns:
           None
     '''
-    run_data = JRC.get_run_data(__file__, __version__).strip()
-    mode_badge_bg = EMAIL_GREEN if ARG.WRITE else EMAIL_AMBER
+    run_data = (JRC.get_run_data(__file__, __version__).strip()
+                + f" &middot; manifold: {ARG.MANIFOLD}")
     mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
-
+    mode_tone = 'good' if ARG.WRITE else 'warn'
     kpis = ''.join([
-        html_kpi_card(f"{COUNT['orcid']:,}", "Authors read"),
-        html_kpi_card(f"{COUNT['updated']:,}", "Authors updated",
-                      'good' if COUNT['updated'] else 'neutral'),
-        html_kpi_card(f"{COUNT['written']:,}", "Authors written",
-                      'good' if COUNT['written'] else 'neutral'),
-        html_kpi_card(f"{COUNT['alumni']:,}", "Former employees",
-                      'amber' if COUNT['alumni'] else 'neutral'),
+        JE.kpi_card(f"{COUNT['orcid']:,}", "Authors read", width='25%'),
+        JE.kpi_card(f"{COUNT['updated']:,}", "Authors updated",
+                    'good' if COUNT['updated'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['written']:,}", "Authors written",
+                    'good' if COUNT['written'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['alumni']:,}", "Former employees",
+                    'warn' if COUNT['alumni'] else 'neutral', '25%'),
     ])
-
     breakdown_rows = [
         ("Names updated", f"{COUNT['name']:,}"),
         ("Affiliations updated", f"{COUNT['affiliations']:,}"),
@@ -569,47 +510,13 @@ def generate_email(changes_log):
         ("Set to former employee", f"{COUNT['alumni']:,}"),
         ("No People record (skipped)", f"{COUNT['no_people_record']:,}"),
     ]
-    breakdown_section = (html_section_header("&#128202; Change Breakdown")
-                         + html_metric_rows(breakdown_rows))
-
-    changes_section = (html_section_header(f"&#128100; Authors With Changes "
-                                           f"({len(changes_log):,})")
-                       + html_changes_table(changes_log))
-
-    msg = (
-        f'<div style="font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;'
-        f'background-color:#eef1f4;padding:8px 0;">'
-        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>'
-        '<td align="center" style="padding:8px 14px 32px 14px;">'
-        '<table role="presentation" width="720" cellpadding="0" cellspacing="0" '
-        'bgcolor="#ffffff" '
-        f'style="max-width:720px;width:100%;background-color:#ffffff;border-radius:10px;'
-        f'border:1px solid {EMAIL_BORDER};overflow:hidden;">'
-        f'<tr><td bgcolor="{EMAIL_NAVY}" style="background-color:{EMAIL_NAVY};'
-        f'padding:22px 28px;">'
-        f'<div style="color:#ffffff;font-size:19px;font-weight:600;">'
-        f'{os.path.basename(__file__)}&nbsp;'
-        f'<span style="font-weight:400;opacity:.7;font-size:14px;">v{__version__}</span></div>'
-        f'<div style="color:#c9d6e6;font-size:12.5px;margin-top:6px;">{run_data} &middot; '
-        f'manifold: {ARG.MANIFOLD} &middot; '
-        f'<span style="background-color:{mode_badge_bg};color:#fff;border-radius:10px;'
-        f'padding:1px 9px;font-size:11px;font-weight:600;letter-spacing:.03em;">'
-        f'{mode_label}</span></div></td></tr>'
-        f'<tr><td style="padding:22px 22px 6px 22px;">'
-        # cellspacing (not CSS margin, which <td> mostly ignores) puts a real gap
-        # between the KPI tiles; Outlook's Word engine honors this old-school
-        # HTML attribute far more reliably than CSS spacing tricks.
-        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="6"><tr>'
-        f'{kpis}</tr></table></td></tr>'
-        f'<tr><td style="padding:18px 28px 4px 28px;">{breakdown_section}</td></tr>'
-        f'<tr><td style="padding:20px 28px 4px 28px;">{changes_section}</td></tr>'
-        f'<tr><td bgcolor="{EMAIL_STRIPE_BG}" style="padding:18px 28px;'
-        f'background-color:{EMAIL_STRIPE_BG};color:{EMAIL_GRAY};'
-        f'font-size:11px;text-align:center;border-top:1px solid {EMAIL_BORDER};">'
-        'Generated by update_janelians_from_people.py &middot; Data and Information Services '
-        '&middot; Janelia Research Campus</td></tr>'
-        '</table></td></tr></table></div>')
-
+    breakdown = (JE.section_header("&#128202; Change Breakdown")
+                 + html_metric_rows(breakdown_rows))
+    changes = (JE.section_header(f"&#128100; Authors With Changes ({len(changes_log):,})")
+               + html_changes_table(changes_log))
+    body = JE.body_row(breakdown) + JE.body_row(changes)
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
     subject = "Janelians updated from People system"
     email = DIS['developer'] if ARG.TEST else DIS['receivers']
     filename = 'people_orcid_updates.json'


### PR DESCRIPTION
Replace the per-script inline run-summary email code (the html_* helpers and EMAIL_* palettes, originally hand-copied from sync_citations.py) with the shared jrc_email library across five programs: sync_citations, add_people_to_orcid, apply_orcids, sync_openalex, and update_janelians_from_people.

Each now builds the banner / KPI-row / footer shell via JE.render, its KPI tiles via JE.kpi_card, and (where applicable) section headers via JE.section_header. Components jrc_email has no primitive for are kept as inline helpers: the label/value Change-Breakdown tables; sync_citations' usage cards, mini bar chart and multi-column increases table; the People / Author->ORCID / Authors->Changes tables; and the unmapped-license list. sync_citations keeps its table-based html_section_header on purpose, since its bespoke tables rely on that structure to avoid an Outlook div-before-table tag leak.

Recipients (developer vs receivers / --test), subjects, attachments, and the WRITE/DRY-RUN mode badge are preserved; ~400 fewer lines of duplicated email HTML overall. Version bumps: sync_citations 1.12.2, add_people_to_orcid 7.3.3, apply_orcids 2.1.3, sync_openalex 4.2.2, update_janelians_from_people 6.3.3.

@stuarteberg