### PR TITLE
feat(email): house-style run-summary emails across more sync/bin programs

### DIFF
--- a/sync/bin/sync_datacite_legal.py
+++ b/sync/bin/sync_datacite_legal.py
@@ -5,19 +5,21 @@
 import argparse
 import collections
 from operator import attrgetter
+import os
 import sys
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 import dis_license_lib as DISL
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,duplicate-code
 
 DB = {}
 COUNT = collections.defaultdict(lambda: 0, {})
-ARG = LOGGER = None
+ARG = DISCONFIG = LOGGER = None
 LICENSE = {}
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -119,6 +121,56 @@ def processing():
     print(f"{'DOIs skipped (Unpaywall down):':<32}{COUNT['unpaywall_unreachable']:,}")
     print(f"{'DOIs skipped (OpenAlex down):':<32}{COUNT['openalex_unreachable']:,}")
 
+
+def generate_email():
+    ''' Build and send the HTML run-summary email (jrc_email house style): KPI
+        tiles for the headline counts and a table of the license-resolution
+        diagnostics. Sent only with --test (to the developer) or --write (to the
+        receivers list).
+        Keyword arguments:
+          None
+        Returns:
+          None
+    '''
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['read']:,}", "DOIs read", width='25%'),
+        JE.kpi_card(f"{COUNT['updated']:,}", "Licenses set",
+                    'good' if COUNT['updated'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['no_license']:,}", "No license",
+                    'bad' if COUNT['no_license'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['pmc_skipped_no_id']:,}", "PMC: no ID", width='25%'),
+    ])
+    diagnostics = [("PMC 429 exhausted", COUNT['pmc_429_exhausted']),
+                   ("PMC unreachable", COUNT['pmc_unreachable']),
+                   ("Unpaywall not indexed", COUNT['unpaywall_not_indexed']),
+                   ("Unpaywall unreachable", COUNT['unpaywall_unreachable']),
+                   ("OpenAlex unreachable", COUNT['openalex_unreachable'])]
+    rows = ""
+    for idx, (label, val) in enumerate(diagnostics):
+        bgc = "#f4f6f8" if idx % 2 == 0 else "#ffffff"
+        rows += (f'<tr bgcolor="{bgc}" style="background-color:{bgc};">'
+                 f'<td style="padding:6px 12px;">{label}</td>'
+                 f'<td style="padding:6px 12px;" align="right">{val:,}</td></tr>')
+    diag_table = (
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        'style="border-collapse:collapse;font-size:13px;">'
+        '<tr style="color:#5b6b7c;font-size:10.5px;text-transform:uppercase;'
+        'letter-spacing:.03em;"><td style="padding:6px 12px;">Resolution diagnostic</td>'
+        '<td style="padding:6px 12px;" align="right">DOIs</td></tr>'
+        + rows + '</table>')
+    body = JE.body_row(JE.section_header("&#9878; License resolution diagnostics") + diag_table)
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
+    email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
+    try:
+        LOGGER.info(f"Sending email to {email}")
+        JRC.send_email(msg, DISCONFIG['sender'], email, "DataCite legal sync", mime='html')
+    except Exception as err:
+        LOGGER.error(err)
+
 # -----------------------------------------------------------------------------
 
 if __name__ == '__main__':
@@ -129,12 +181,17 @@ if __name__ == '__main__':
                         help='MongoDB manifold (dev, prod)')
     PARSER.add_argument('--write', dest='WRITE', action='store_true',
                         default=False, help='Write to database')
+    PARSER.add_argument('--test', dest='TEST', action='store_true',
+                        default=False, help='Send email to developer only')
     PARSER.add_argument('--verbose', dest='VERBOSE', action='store_true',
                         default=False, help='Flag, Chatty')
     PARSER.add_argument('--debug', dest='DEBUG', action='store_true',
                         default=False, help='Flag, Very chatty')
     ARG = PARSER.parse_args()
     LOGGER = JRC.setup_logging(ARG)
+    DISCONFIG = JRC.simplenamespace_to_dict(JRC.get_config("dis"))
     initialize_program()
     processing()
+    if ARG.TEST or ARG.WRITE:
+        generate_email()
     terminate_program()

--- a/sync/bin/sync_full_text.py
+++ b/sync/bin/sync_full_text.py
@@ -2,7 +2,7 @@
     Update links to full-text files for DOIs. PDFs are preferred.
 '''
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 import argparse
 import collections
@@ -15,6 +15,7 @@ from metapub import FindIt
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation
 
@@ -23,7 +24,7 @@ DB = {}
 # Counters
 COUNT = collections.defaultdict(lambda: 0, {})
 # Global variables
-ARG = CONFIG = LOGGER = None
+ARG = CONFIG = DISCONFIG = LOGGER = None
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -142,6 +143,49 @@ def download_file(doi, url):
         LOGGER.error(f"Error downloading {url}: {err}")
 
 
+def generate_email():
+    ''' Send the house-style HTML run-summary email (jrc_email): KPI tiles for the
+        headline counts plus a per-source full-text breakdown table. Sent to the
+        developer only with --test, otherwise to the configured receivers.
+        Keyword arguments:
+          None
+        Returns:
+          None
+    '''
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['read']:,}", "DOIs checked", width='25%'),
+        JE.kpi_card(f"{COUNT['updated']:,}", "Full text found",
+                    'good' if COUNT['updated'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['not_found']:,}", "Not found",
+                    'bad' if COUNT['not_found'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['downloaded']:,}", "PDFs downloaded", width='25%'),
+    ])
+    sources = [("bioRxiv", COUNT['biorxiv']), ("Crossref", COUNT['link']),
+               ("eLife", COUNT['elife']), ("OpenAlex", COUNT['openalex']),
+               ("OA.Report", COUNT['oa']), ("PMC", COUNT['pmc'])]
+    rows = ""
+    for idx, (label, val) in enumerate(sources):
+        bgc = "#f4f6f8" if idx % 2 == 0 else "#ffffff"
+        rows += (f'<tr bgcolor="{bgc}" style="background-color:{bgc};">'
+                 f'<td style="padding:6px 12px;">{label}</td>'
+                 f'<td style="padding:6px 12px;" align="right">{val:,}</td></tr>')
+    table = (
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        'style="border-collapse:collapse;font-size:13px;">'
+        '<tr style="color:#5b6b7c;font-size:10.5px;text-transform:uppercase;'
+        'letter-spacing:.03em;"><td style="padding:6px 12px;">Source</td>'
+        '<td style="padding:6px 12px;" align="right">Full text found</td></tr>'
+        + rows + '</table>')
+    body = JE.body_row(JE.section_header("&#128196; Full-text sources") + table)
+    email_html = JE.render(os.path.basename(__file__), __version__, run_data,
+                           mode_label, mode_tone, kpis, body)
+    recipient = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
+    JRC.send_email(email_html, DISCONFIG['sender'], recipient, "Full-text sync", mime='html')
+
+
 def processing():
     ''' Update full-text links for DOIs
         Keyword arguments:
@@ -201,6 +245,7 @@ def processing():
         with open('dois_missing_fulltext.txt', 'w', encoding='utf-8') as f:
             for line in notfound:
                 f.write(line + '\n')
+    COUNT['read'] = cnt
     print(f"DOIs checked:    {cnt:,}")
     print("Sources:")
     print(f"  bioRxiv:       {COUNT['biorxiv']:,}")
@@ -212,6 +257,8 @@ def processing():
     print(f"DOIs updated:    {COUNT['updated']:,}")
     print(f"PDFs downloaded: {COUNT['downloaded']:,}")
     print(f"DOIs not found:  {COUNT['not_found']:,}")
+    if ARG.TEST or ARG.WRITE:
+        generate_email()
 
 # -----------------------------------------------------------------------------
 
@@ -227,6 +274,8 @@ if __name__ == '__main__':
     PARSER.add_argument('--manifold', dest='MANIFOLD', action='store',
                         default='prod', choices=['dev', 'prod'],
                         help='MongoDB manifold (dev, prod)')
+    PARSER.add_argument('--test', dest='TEST', action='store_true',
+                        default=False, help='Send email to developer only')
     PARSER.add_argument('--write', dest='WRITE', action='store_true',
                         default=False, help='Write to database/config system')
     PARSER.add_argument('--verbose', dest='VERBOSE', action='store_true',
@@ -236,6 +285,7 @@ if __name__ == '__main__':
     ARG = PARSER.parse_args()
     LOGGER = JRC.setup_logging(ARG)
     initialize_program()
+    DISCONFIG = JRC.simplenamespace_to_dict(JRC.get_config("dis"))
     CONFIG = configparser.ConfigParser()
     CONFIG.read('config.ini')
     processing()

--- a/sync/bin/sync_pmid_to_dois.py
+++ b/sync/bin/sync_pmid_to_dois.py
@@ -3,7 +3,7 @@
     DOI needs to be in the PubMed or PubMed Central archive.
 '''
 
-__version__ = '6.3.0'
+__version__ = '6.3.1'
 
 import argparse
 import collections
@@ -17,6 +17,7 @@ from metapub import PubMedFetcher
 import metapub.exceptions
 from tqdm import tqdm
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation
 
@@ -114,16 +115,49 @@ def postprocessing(audit, error):
         LOGGER.info(f"Wrote {len(audit):,} update{'' if len(audit) == 1 else 's'} to {filename}")
     if (not COUNT['updated']) or (not (ARG.TEST or ARG.WRITE)):
         return
-    text = f"<pre>PMIDs have been added to DOIs.\n\n{msg}</pre>"
+    # House-style HTML run summary (jrc_email): KPI tiles for the headline counts
+    # and a compact "Update breakdown" table for the per-source detail (jrc_email
+    # has no label/value-table primitive), with the updates file attached.
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['doi']:,}", "DOIs read", width='25%'),
+        JE.kpi_card(f"{COUNT['updated']:,}", "DOIs updated",
+                    'good' if COUNT['updated'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['written']:,}", "DOIs written",
+                    'good' if COUNT['written'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['removed']:,}", "PMIDs removed",
+                    'bad' if COUNT['removed'] else 'neutral', '25%'),
+    ])
+    breakdown = [("PubMed (eutils)", COUNT['PubMed (eutils)']), ("PubMed", COUNT['PubMed']),
+                 ("OA", COUNT['OA']), ("MeSH updates", COUNT['mesh'])]
+    rows = ""
+    for idx, (label, val) in enumerate(breakdown):
+        bgc = "#f4f6f8" if idx % 2 == 0 else "#ffffff"
+        rows += (f'<tr bgcolor="{bgc}" style="background-color:{bgc};">'
+                 f'<td style="padding:6px 12px;">{label}</td>'
+                 f'<td style="padding:6px 12px;" align="right">{val:,}</td></tr>')
+    breakdown_table = (
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        'style="border-collapse:collapse;font-size:13px;">'
+        '<tr style="color:#5b6b7c;font-size:10.5px;text-transform:uppercase;'
+        'letter-spacing:.03em;"><td style="padding:6px 12px;">Source</td>'
+        '<td style="padding:6px 12px;" align="right">DOIs updated</td></tr>'
+        + rows + '</table>')
+    body = JE.body_row(JE.section_header("&#128220; Update breakdown") + breakdown_table)
     if audit:
-        text += "<br><br>Please see the attached file for the new records."
+        body += JE.body_row("<div style='font-size:13px;color:#5b6b7c;'>See the attached "
+                            "<b>pmid_dois_updates.json</b> for the updated records.</div>")
+    email_html = JE.render(os.path.basename(__file__), __version__, run_data,
+                           mode_label, mode_tone, kpis, body)
     subject = "PMIDs added to DOIs"
     email = DIS['developer'] if ARG.TEST else DIS['receivers']
     if audit:
-        JRC.send_email(text, DIS['sender'], email, subject,
+        JRC.send_email(email_html, DIS['sender'], email, subject,
                        attachment=filename, mime='html')
     else:
-        JRC.send_email(text, DIS['sender'], email, subject, mime='html')
+        JRC.send_email(email_html, DIS['sender'], email, subject, mime='html')
 
 
 def get_mesh_array(mesh):

--- a/sync/bin/sync_suporg_to_mongo.py
+++ b/sync/bin/sync_suporg_to_mongo.py
@@ -2,15 +2,17 @@
     Update the MongoDB suporg collection with data from the People system.
 '''
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 import argparse
 import collections
+import html
 from operator import attrgetter
 import os
 import sys
 import jrc_common.jrc_common as JRC
 import doi_common.doi_common as DL
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,logging-not-lazy
 
@@ -65,6 +67,67 @@ def initialize_program():
         terminate_program(err)
 
 
+def html_suporg_table(entries):
+    ''' Build a zebra-striped Name/Code/Active table for added suporgs.
+        Deliberately no per-cell border-radius - plain background-color
+        striping is the pattern that survives Outlook's Word rendering engine
+        (see the equivalent list tables in add_people_to_orcid.py).
+        Keyword arguments:
+          entries: list of {name, code, active} dicts
+        Returns:
+          HTML table
+    '''
+    rows = []
+    for i, entry in enumerate(entries):
+        striped = i % 2 == 0
+        bgattr = f' bgcolor="{JE.STRIPE_BG}"' if striped else ''
+        bg = f'background-color:{JE.STRIPE_BG};' if striped else ''
+        name = html.escape(entry['name'])
+        code = html.escape(str(entry['code']))
+        badge = JE.pill(JE.GREEN_BG, JE.GREEN, '&#10003; Active') if entry['active'] else ''
+        rows.append(
+            f'<tr{bgattr} style="{bg}">'
+            f'<td style="padding:8px 10px;">{name}</td>'
+            f'<td style="padding:8px 10px;color:{JE.GRAY};">{code}</td>'
+            f'<td style="padding:8px 10px;" align="right">{badge}</td></tr>')
+    rows.append('<tr><td colspan="3" style="height:1px;line-height:1px;font-size:1px;">'
+                '&nbsp;</td></tr>')
+    return ('<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+            'style="border-collapse:collapse;font-size:12.5px;">'
+            + "".join(rows) + '</table>')
+
+
+def generate_email(people_count, mongo_count, added):
+    ''' Generate and send the HTML run-summary email for suporgs added to
+        MongoDB from the People system.
+        Keyword arguments:
+          people_count: number of suporgs found in People
+          mongo_count: number of suporgs already in MongoDB
+          added: list of {name, code, active} dicts for suporgs added
+        Returns:
+          None
+    '''
+    run_data = (JRC.get_run_data(__file__, __version__).strip()
+                + f" &middot; manifold: {ARG.MANIFOLD}")
+    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
+    kpis = ''.join([
+        JE.kpi_card(f"{people_count:,}", "Suporgs in People", width='33%'),
+        JE.kpi_card(f"{mongo_count:,}", "Suporgs in MongoDB", width='33%'),
+        JE.kpi_card(f"{len(added):,}", "Suporgs added", 'good', width='33%'),
+    ])
+    body = JE.body_row(JE.section_header(f"&#127970; Suporgs Added ({len(added):,})")
+                       + html_suporg_table(added))
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
+    email = DIS['developer'] if ARG.TEST else DIS['receivers']
+    try:
+        LOGGER.info(f"Sending email to {email}")
+        JRC.send_email(msg, DIS['sender'], email, 'Suporgs added', mime='html')
+    except Exception as err:
+        LOGGER.error(err)
+
+
 def update_suporgs():
     ''' Update supervisory organizations
         Keyword arguments:
@@ -78,23 +141,20 @@ def update_suporgs():
     for suporg, val in people.items():
         if suporg not in mongo and suporg not in IGNORE:
             LOGGER.info(f"Adding {suporg} with code {val['SUPORGCODE']}")
+            active = bool(val.get('active'))
             payload = {'name': suporg, 'code': val['SUPORGCODE']}
-            if 'active' in val and val['active']:
+            if active:
                 payload['active'] = True
             if ARG.WRITE:
                 DB['dis'].suporg.insert_one(payload)
-            active = ' (active)' if 'active' in payload else ''
-            added.append(f"{suporg}: {val['SUPORGCODE']}{active}")
+            added.append({'name': suporg, 'code': val['SUPORGCODE'], 'active': active})
             COUNT['added'] += 1
     print(f"Suporgs in People:  {len(people):,}")
     print(f"Suporgs in MongoDB: {len(mongo):,}")
     print(f"Suporgs added:      {COUNT['added']:,}")
     if (not added) or (not (ARG.TEST or ARG.WRITE)):
         return
-    text = "The following suporgs have been added to the database:<br>"
-    text += "<br>".join(added)
-    email = DIS['developer'] if ARG.TEST else DIS['receivers']
-    JRC.send_email(text, DIS['sender'], email, 'Suporgs added', mime='html')
+    generate_email(len(people), len(mongo), added)
 
 # -----------------------------------------------------------------------------
 

--- a/sync/bin/sync_suporg_to_org_group.py
+++ b/sync/bin/sync_suporg_to_org_group.py
@@ -2,22 +2,28 @@
     Update the MongoDB org_group collection with data from the People system.
 '''
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 import argparse
+import collections
+import html
 import json
 from operator import attrgetter
 import os
 import sys
 import jrc_common.jrc_common as JRC
+import jrc_email.jrc_email as JE
 
 # pylint: disable=broad-exception-caught,logging-fstring-interpolation,logging-not-lazy
 
 # Database
 DB = {}
 # Global variables
-ARG = LOGGER = None
+ARG = DISCONFIG = LOGGER = None
 IGNORE = {}
+# Run summary for the email
+COUNT = collections.defaultdict(lambda: 0, {})
+CHANGES = []
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -181,6 +187,16 @@ def process_list(raw, rec):
             organizations.add(org)
     organizations = sorted(list(organizations))
     print(json.dumps(organizations, indent=2))
+    # Track the membership delta for the run-summary email. Computed regardless of
+    # --write so a dry run still reports what would change.
+    added = sorted(set(organizations) - original_members)
+    removed = sorted(original_members - set(organizations))
+    COUNT['groups'] += 1
+    if added or removed:
+        COUNT['groups_changed'] += 1
+        COUNT['orgs_added'] += len(added)
+        COUNT['orgs_removed'] += len(removed)
+        CHANGES.append({'group': rec['group'], 'added': added, 'removed': removed})
     if not ARG.WRITE:
         return
     try:
@@ -189,13 +205,10 @@ def process_list(raw, rec):
                                                   )
         LOGGER.info(f"Updated {rec['group']}: {result.modified_count} " \
                     + f"record{'' if result.modified_count == 1 else 's'} modified")
-        if result.modified_count > 0:
-            added = set(organizations) - original_members
-            removed = original_members - set(organizations)
-            if added:
-                LOGGER.info(f"Added organizations: {sorted(list(added))}")
-            if removed:
-                LOGGER.info(f"Removed organizations: {sorted(list(removed))}")
+        if added:
+            LOGGER.info(f"Added organizations: {added}")
+        if removed:
+            LOGGER.info(f"Removed organizations: {removed}")
     except Exception as err:
         terminate_program(err)
 
@@ -251,6 +264,63 @@ def update_orgs():
         ARG.PID = rec['manager']
         process_single_group()
 
+
+def generate_email():
+    ''' Build and send the HTML run-summary email (jrc_email house style): KPI
+        tiles for groups processed/changed and orgs added/removed, plus a table of
+        each changed group's added/removed organizations. Recipient is the
+        developer with --test, else the receivers list.
+        Keyword arguments:
+          None
+        Returns:
+          None
+    '''
+    run_data = JRC.get_run_data(__file__, __version__).strip()
+    run_data += f" &middot; manifold: {ARG.MANIFOLD}"
+    mode_label = 'WRITE' if ARG.WRITE else 'DRY RUN'
+    mode_tone = 'good' if ARG.WRITE else 'warn'
+    kpis = ''.join([
+        JE.kpi_card(f"{COUNT['groups']:,}", "Groups processed", width='25%'),
+        JE.kpi_card(f"{COUNT['groups_changed']:,}", "Groups changed",
+                    'good' if COUNT['groups_changed'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['orgs_added']:,}", "Orgs added",
+                    'good' if COUNT['orgs_added'] else 'neutral', '25%'),
+        JE.kpi_card(f"{COUNT['orgs_removed']:,}", "Orgs removed",
+                    'bad' if COUNT['orgs_removed'] else 'neutral', '25%'),
+    ])
+    if CHANGES:
+        rows = ""
+        for idx, chg in enumerate(CHANGES):
+            bgc = "#f4f6f8" if idx % 2 == 0 else "#ffffff"
+            added = html.escape(", ".join(chg['added'])) if chg['added'] else "&mdash;"
+            removed = html.escape(", ".join(chg['removed'])) if chg['removed'] else "&mdash;"
+            rows += (f'<tr bgcolor="{bgc}" style="background-color:{bgc};">'
+                     f'<td style="padding:6px 12px;vertical-align:top;font-weight:600;">'
+                     f'{html.escape(chg["group"])}</td>'
+                     f'<td style="padding:6px 12px;vertical-align:top;color:#256029;">{added}</td>'
+                     f'<td style="padding:6px 12px;vertical-align:top;color:#5b6b7c;">'
+                     f'{removed}</td></tr>')
+        table = (
+            '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+            'style="border-collapse:collapse;font-size:13px;">'
+            '<tr style="color:#5b6b7c;font-size:10.5px;text-transform:uppercase;'
+            'letter-spacing:.03em;"><td style="padding:6px 12px;">Group</td>'
+            '<td style="padding:6px 12px;">Orgs added</td>'
+            '<td style="padding:6px 12px;">Orgs removed</td></tr>' + rows + '</table>')
+        body = JE.body_row(
+            JE.section_header(f"&#128101; Changed groups ({COUNT['groups_changed']:,})") + table)
+    else:
+        body = JE.body_row('<div style="font-size:13px;color:#5b6b7c;">'
+                           'No org-group membership changes.</div>')
+    msg = JE.render(os.path.basename(__file__), __version__, run_data,
+                    mode_label, mode_tone, kpis, body)
+    email = DISCONFIG['developer'] if ARG.TEST else DISCONFIG['receivers']
+    try:
+        LOGGER.info(f"Sending email to {email}")
+        JRC.send_email(msg, DISCONFIG['sender'], email, "SupOrg to org-group sync", mime='html')
+    except Exception as err:
+        LOGGER.error(f"Could not send email: {err}")
+
 # -----------------------------------------------------------------------------
 
 if __name__ == '__main__':
@@ -266,12 +336,17 @@ if __name__ == '__main__':
                       help='MongoDB manifold (dev, prod)')
     PARSER.add_argument('--write', dest='WRITE', action='store_true',
                         default=False, help='Write to database/config system')
+    PARSER.add_argument('--test', dest='TEST', action='store_true',
+                        default=False, help='Send email to developer only')
     PARSER.add_argument('--verbose', dest='VERBOSE', action='store_true',
                         default=False, help='Flag, Chatty')
     PARSER.add_argument('--debug', dest='DEBUG', action='store_true',
                         default=False, help='Flag, Very chatty')
     ARG = PARSER.parse_args()
     LOGGER = JRC.setup_logging(ARG)
+    DISCONFIG = JRC.simplenamespace_to_dict(JRC.get_config("dis"))
     initialize_program()
     update_orgs()
+    if ARG.TEST or ARG.WRITE:
+        generate_email()
     terminate_program()


### PR DESCRIPTION
Give five sync/bin programs a jrc_email house-style run-summary.

New emails, each with a --test flag (developer-only; else receivers), gated on --test/--write, and loading the dis config where the program didn't before:
- sync_datacite_legal.py (2.1.0): KPI tiles (read / licenses set / no license / PMC no-id) plus a license-resolution diagnostics table.
- sync_full_text.py (2.1.0): KPI tiles (checked / found / not-found / downloaded) plus a full-text-sources breakdown table.
- sync_suporg_to_org_group.py (1.1.0): adds change-tracking (it had none) and KPIs plus a per-group added/removed table. The added/removed set-diff now runs before the --write gate, so a dry run / --test reports what would change.

Existing emails restyled onto jrc_email:
- sync_pmid_to_dois.py (6.3.1): from a <pre> count dump to KPIs plus an update-breakdown table.
- sync_suporg_to_mongo.py (1.0.1): from a flat suporg list to KPIs plus a Name/Code/Active suporg table.

Bespoke label/value tables are kept inline (jrc_email has no such primitive); recipients, subjects, attachments, and existing behavior are preserved.

@stuarteberg