### PR TITLE
fix(email): only email on --test or a --write run that changed records

### DIFF
--- a/sync/bin/sync_datacite_legal.py
+++ b/sync/bin/sync_datacite_legal.py
@@ -19,7 +19,7 @@ COUNT = collections.defaultdict(lambda: 0, {})
 ARG = DISCONFIG = LOGGER = None
 LICENSE = {}
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 def terminate_program(msg=None):
     ''' Terminate the program gracefully
@@ -192,6 +192,6 @@ if __name__ == '__main__':
     DISCONFIG = JRC.simplenamespace_to_dict(JRC.get_config("dis"))
     initialize_program()
     processing()
-    if ARG.TEST or ARG.WRITE:
+    if ARG.TEST or (ARG.WRITE and COUNT['updated']):
         generate_email()
     terminate_program()

--- a/sync/bin/sync_full_text.py
+++ b/sync/bin/sync_full_text.py
@@ -2,7 +2,7 @@
     Update links to full-text files for DOIs. PDFs are preferred.
 '''
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 import argparse
 import collections
@@ -257,7 +257,7 @@ def processing():
     print(f"DOIs updated:    {COUNT['updated']:,}")
     print(f"PDFs downloaded: {COUNT['downloaded']:,}")
     print(f"DOIs not found:  {COUNT['not_found']:,}")
-    if ARG.TEST or ARG.WRITE:
+    if ARG.TEST or (ARG.WRITE and COUNT['updated']):
         generate_email()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
sync_datacite_legal.py and sync_full_text.py sent their run-summary email on any --test or --write run. Now they email on --test (to the developer) or when a --write run actually changed records (COUNT['updated'] > 0), so a scheduled --write run that updates nothing no longer sends a noise email. A plain dry run still sends nothing. Bumps both to 2.1.1.

@stuarteberg