### PR TITLE
refactor(ui): route dois_top colors through get_colors_by_count (chart policy)

### DIFF
--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -24,7 +24,6 @@ from urllib.parse import quote, unquote
 import concurrent.futures
 import dateutil.parser
 import dateutil.tz
-from bokeh.palettes import all_palettes, plasma
 import bson
 from flask import (Flask, make_response, render_template, request, jsonify, redirect, send_file)
 from flask_cors import CORS
@@ -49,7 +48,7 @@ from dis_state import CVTERM, PROJECT
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,too-many-lines,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
 
-__version__ = "120.10.1"
+__version__ = "120.10.2"
 # Database
 DB = {}
 INSENSITIVE = Collation(locale='en', strength=CollationStrength.PRIMARY)
@@ -13835,11 +13834,10 @@ def dois_top(show="journal", num=10):
     height = 600
     if num > 23:
         height += 22 * (num - 23)
-    colors = plasma(len(top))
-    if len(top) <= 10:
-        colors = all_palettes['Category10'][len(top)]
-    elif len(top) <= 20:
-        colors = all_palettes['Category20'][len(top)]
+    # Audit chart policy: route N-category colours through get_colors_by_count
+    # (it applies the same Category10/20/plasma tiers this used to hand-roll, and
+    # safely handles 1-2 series where Category10[<3] would KeyError).
+    colors = DP.get_colors_by_count(len(top))
     chartscript, chartdiv = DP.stacked_bar_chart(data, f"DOIs published by year for top {num} tags",
                                                  xaxis="years", yaxis=top, width=900, height=height,
                                                  colors=colors)


### PR DESCRIPTION
Replace the hand-rolled plasma/Category10/Category20 palette selection in dois_top with DP.get_colors_by_count(len(top)) - the shared N-category color helper the audit chart-policy calls for (it applies the same palette tiers). This also fixes a latent crash: the old code indexed all_palettes['Category10'][len(top)], which KeyErrors for 1-2 tags (Bokeh's Category10 palette starts at 3); get_colors_by_count returns green / SOURCE_PALETTE for those cases. Drops the now-unused "from bokeh.palettes import all_palettes, plasma" import.

Chart-policy size-normalization was reviewed and left as-is: the flagged size differences are content-driven (fewer bars/slices -> smaller charts; side vs main pies), not arbitrary drift.

Bumps __version__ to 120.10.2.

@stuarteberg