### PR TITLE
fix(ui): define the .flexcol class in main.css (was an undefined footgun)

### DIFF
--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -48,7 +48,7 @@ from dis_state import CVTERM, PROJECT
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,too-many-lines,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
 
-__version__ = "120.13.5"
+__version__ = "120.13.6"
 # Database
 DB = {}
 INSENSITIVE = Collation(locale='en', strength=CollationStrength.PRIMARY)

--- a/api/static/css/main.css
+++ b/api/static/css/main.css
@@ -294,6 +294,17 @@ table.property {
   flex: 1;
 }
 
+/* One column inside a .flexrow (e.g. a table beside its chart). The parent
+   .flexrow supplies the flex context; each column sizes to its content and wraps
+   below on a narrow viewport, with callers setting an explicit width/flex-basis
+   inline where a fixed column width is needed. `flex: 0 1 auto` is the default
+   flex-item value, so this changes nothing visually - it just makes .flexcol a
+   real, documented class instead of an undefined one that worked only by relying
+   on the parent's flex context (used ~23x in dis_responder + bokeh.html/custom.html). */
+.flexcol {
+  flex: 0 1 auto;
+}
+
 .fas {
   color: white;
   text-shadow: 1px 1px #333


### PR DESCRIPTION
The table-beside-chart columns use class="flexcol" ~23x (dis_responder.py plus bokeh.html / custom.html), but .flexcol was never defined in main.css - only .flexrow / .flexrowc / .flexcolumn are. It "worked" only because the parent .flexrow is display:flex, so the children got default flex-item behavior; a future reader sees a class with no CSS and can't tell if it's intentional or a typo.

Define .flexcol explicitly as `flex: 0 1 auto` - the default flex-item value, so nothing changes visually - which makes it a real, documented class. Chose this over migrating all ~23 sites (+ 2 templates, each with bespoke inline width/margin) to the two_col() helper: that would churn layouts for no user-visible gain. (Note: .flexcolumn is defined but unused; left as-is.)

Addresses UI-audit row 144 (2D - .flexcol undefined). Bumps __version__ to 120.13.6.