### PR TITLE
feat(ui): accept a list of DOIs/PMIDs (paste or file upload) in the home lookup box

### DIFF
--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -48,7 +48,7 @@ from dis_state import CVTERM, PROJECT
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,too-many-lines,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
 
-__version__ = "120.13.9"
+__version__ = "120.14.0"
 # Database
 DB = {}
 INSENSITIVE = Collation(locale='en', strength=CollationStrength.PRIMARY)
@@ -5088,6 +5088,53 @@ def doi_tabs(doi, row, rowext, data, authors):
                 + f'aria-labelledby="{key}-tab"><br>{val}</div>'
     html += '</div>'
     return html
+
+
+@app.route('/doiui_batch', methods=['POST'])
+def show_doi_batch():
+    ''' Standard DOI table for a whitespace-separated list of DOIs/PMIDs, submitted
+        from the home page's "Find a DOI or PMID" box. A single entry routes to
+        /doiui client-side; this handles two or more. PMIDs (all-digit tokens) are
+        resolved via jrc_pmid, the same way /doiui does; tokens with no matching
+        dois-collection record are listed as not found above the table.
+    '''
+    # Normalize + dedupe (preserving input order); all-digit tokens are PMIDs.
+    pmids, dois, seen = [], [], set()
+    for tok in request.form.get('dois', '').split():
+        token = tok.strip().strip('/').lower()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        (pmids if token.isdigit() else dois).append(token)
+    if not seen:
+        return render_template('warning.html', urlroot=request.url_root,
+                               title=render_warning("No DOIs or PMIDs", 'warning'),
+                               message="You must enter at least one DOI or PMID")
+    try:
+        rows = list(DB['dis'].dois.find({"$or": [{"doi": {"$in": dois}},
+                                                 {"jrc_pmid": {"$in": pmids}}]}))
+    except Exception as err:
+        return inspect_error(err, 'Could not get DOIs')
+    found_dois = {row['doi'] for row in rows}
+    found_pmids = {str(row['jrc_pmid']) for row in rows if row.get('jrc_pmid') is not None}
+    notfound = [t for t in dois if t not in found_dois] \
+               + [t for t in pmids if t not in found_pmids]
+    rows.sort(key=lambda row: DL.get_publishing_date(row) or '', reverse=True)
+    html = ""
+    if notfound:
+        html += render_warning(f"{len(notfound)} of {len(seen):,} entered not found in the "
+                               + "DOI collection: "
+                               + ", ".join(escape(t) for t in notfound), 'warning') + "<br>"
+    if rows:
+        table, _, _ = standard_doi_table(rows, count_card=True)
+        html += table
+    else:
+        html += render_warning("None of the entered DOIs/PMIDs were found in the DOI "
+                               + "collection.", 'warning')
+    endpoint_access()
+    return make_response(render_template('general.html', urlroot=request.url_root,
+                                         title="DOI report", html=html,
+                                         navbar=generate_navbar('DOIs')))
 
 
 @app.route('/doiui/<path:doi>')

--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -48,7 +48,7 @@ from dis_state import CVTERM, PROJECT
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,too-many-lines,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
 
-__version__ = "120.14.0"
+__version__ = "120.14.1"
 # Database
 DB = {}
 INSENSITIVE = Collation(locale='en', strength=CollationStrength.PRIMARY)
@@ -5090,26 +5090,48 @@ def doi_tabs(doi, row, rowext, data, authors):
     return html
 
 
+BATCH_MAX_BYTES = 2_000_000   # cap on an uploaded DOI/PMID list (~2 MB)
+BATCH_MAX_TOKENS = 5000       # cap on the number of ids processed per request
+
+
 @app.route('/doiui_batch', methods=['POST'])
 def show_doi_batch():
-    ''' Standard DOI table for a whitespace-separated list of DOIs/PMIDs, submitted
-        from the home page's "Find a DOI or PMID" box. A single entry routes to
-        /doiui client-side; this handles two or more. PMIDs (all-digit tokens) are
-        resolved via jrc_pmid, the same way /doiui does; tokens with no matching
-        dois-collection record are listed as not found above the table.
+    ''' Standard DOI table for a list of DOIs/PMIDs, submitted from the home page's
+        "Find a DOI or PMID" box (pasted, whitespace-separated) or as an uploaded
+        text/CSV file. A single pasted entry routes to /doiui client-side; this
+        handles two or more, plus any uploaded file. Tokens are split on whitespace
+        or commas (so space-, newline-, tab-, and comma-separated lists all work).
+        PMIDs (all-digit tokens) are resolved via jrc_pmid, the same way /doiui does;
+        tokens with no matching dois-collection record are listed as not found.
     '''
-    # Normalize + dedupe (preserving input order); all-digit tokens are PMIDs.
+    raw = request.form.get('dois', '')
+    upload = request.files.get('file')
+    if upload and upload.filename:
+        # Read at most the cap (+1 byte to detect oversize) rather than the whole file.
+        data = upload.read(BATCH_MAX_BYTES + 1)
+        if len(data) > BATCH_MAX_BYTES:
+            return render_template('warning.html', urlroot=request.url_root,
+                                   title=render_warning("File too large", 'warning'),
+                                   message=f"The uploaded file exceeds the "
+                                           f"{BATCH_MAX_BYTES // 1_000_000} MB limit.")
+        raw += "\n" + data.decode('utf-8-sig', errors='replace')
+    # Normalize + dedupe (preserving input order); split on any run of whitespace or
+    # commas; all-digit tokens are PMIDs. Cap the count to bound the lookup.
     pmids, dois, seen = [], [], set()
-    for tok in request.form.get('dois', '').split():
+    truncated = False
+    for tok in re.split(r'[\s,]+', raw):
         token = tok.strip().strip('/').lower()
         if not token or token in seen:
             continue
+        if len(seen) >= BATCH_MAX_TOKENS:
+            truncated = True
+            break
         seen.add(token)
         (pmids if token.isdigit() else dois).append(token)
     if not seen:
         return render_template('warning.html', urlroot=request.url_root,
                                title=render_warning("No DOIs or PMIDs", 'warning'),
-                               message="You must enter at least one DOI or PMID")
+                               message="You must enter or upload at least one DOI or PMID")
     try:
         rows = list(DB['dis'].dois.find({"$or": [{"doi": {"$in": dois}},
                                                  {"jrc_pmid": {"$in": pmids}}]}))
@@ -5121,6 +5143,9 @@ def show_doi_batch():
                + [t for t in pmids if t not in found_pmids]
     rows.sort(key=lambda row: DL.get_publishing_date(row) or '', reverse=True)
     html = ""
+    if truncated:
+        html += render_warning(f"Only the first {BATCH_MAX_TOKENS:,} entries were processed.",
+                               'warning') + "<br>"
     if notfound:
         html += render_warning(f"{len(notfound)} of {len(seen):,} entered not found in the "
                                + "DOI collection: "

--- a/api/templates/home.html
+++ b/api/templates/home.html
@@ -162,6 +162,11 @@ onload="tableInitialize();"
 
 {% block content %}
 <h2>Search</h2>
+<!-- Standalone (non-nested) form for the DOI/PMID file upload. The file input and
+     button below live inside the main search <form> for layout, but are associated
+     with THIS form via the HTML5 form="doiupload" attribute, so the upload POSTs to
+     /doiui_batch instead of submitting the (GET) search form. -->
+<form id="doiupload" method="POST" action="/doiui_batch" enctype="multipart/form-data"></form>
 <form>
 <div class="flexcontainer">
   <div class="flexitem">
@@ -171,8 +176,20 @@ onload="tableInitialize();"
     <input type="text" class="form-control form-control-lg" id="doi" size=28
            placeholder="one or more, space-separated">
   </div>
-  <div class="flexitem">
+  <div class="flexitemauto">
     <button type="submit" id="doib" class="btn btn-primary" onclick="find_doi(); return false;" href="#">Look up</button>
+  </div>
+  <div class="flexitemauto" style="margin-left: 22px;">
+    <!-- Native file input is hidden and driven by the styled label below (a native
+         file input's "Choose File" text can't be relabeled); a JS onchange shows the
+         picked filename since the hidden input no longer displays it. -->
+    <input type="file" name="file" id="doifile" form="doiupload"
+           accept=".txt,.csv,.tsv,text/plain" style="display:none"
+           onchange="document.getElementById('doifilename').textContent =
+                     this.files.length ? this.files[0].name : 'No file chosen';">
+    <label for="doifile" class="btn btn-outline-secondary" style="margin:0;">Choose file of DOIs or PMIDs</label>
+    <span id="doifilename" style="margin:0 6px; font-style:italic; color:#a8c4e0;">No file chosen</span>
+    <button type="submit" form="doiupload" class="btn btn-outline-primary">Upload list</button>
   </div>
 </div>
 <br>

--- a/api/templates/home.html
+++ b/api/templates/home.html
@@ -39,13 +39,29 @@ $(document).on('keypress', 'input', function(e) {
   return;
 });
   function find_doi() {
-    var focusedElement = $(':focus');
-    if (!$('#doi').val()) {
+    var val = $('#doi').val().trim();
+    if (!val) {
       alert("You must enter a DOI or PMID");
       return;
     }
-    url = "/doiui/" + $("#doi").val();
-    window.location = url;
+    var tokens = val.split(/\s+/).filter(Boolean);
+    if (tokens.length > 1) {
+      // A whitespace-separated list -> POST to the batch report. POST (not a GET
+      // path) avoids URL-length and slash-encoding problems with many DOIs. A
+      // single entry falls through to the normal /doiui route below.
+      var form = document.createElement('form');
+      form.method = 'POST';
+      form.action = '/doiui_batch';
+      var input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = 'dois';
+      input.value = val;
+      form.appendChild(input);
+      document.body.appendChild(form);
+      form.submit();
+      return;
+    }
+    window.location = "/doiui/" + tokens[0];
   }
   function find_dois() {
     if (!$('#doiname').val()) {
@@ -152,7 +168,8 @@ onload="tableInitialize();"
   <span class="form-control-lg">Find a DOI or PMID:</span>
   </div>
   <div class="flexitem">
-    <input type="text" class="form-control form-control-lg" id="doi" size=28>
+    <input type="text" class="form-control form-control-lg" id="doi" size=28
+           placeholder="one or more, space-separated">
   </div>
   <div class="flexitem">
     <button type="submit" id="doib" class="btn btn-primary" onclick="find_doi(); return false;" href="#">Look up</button>


### PR DESCRIPTION
The home "Find a DOI or PMID" box now also accepts several DOIs/PMIDs separated by
whitespace, or a text/CSV file via a new "Upload list" control. A single entry
still routes to /doiui as before; two or more (or any uploaded file) POST to a new
/doiui_batch endpoint.

- Client-side, find_doi() splits the box on whitespace: one token -> /doiui/<token>,
  several -> a POSTed batch report.
- /doiui_batch resolves each token (all-digit tokens are PMIDs, looked up via
  jrc_pmid the same way /doiui does; otherwise a DOI), fetches the matching
  dois-collection records, and renders them in the standard DOI table (DOI-count
  card, version-filter toggle, TSV download). Tokens with no match are listed above
  the table as "not found".
- File upload uses a standalone (non-nested) form associated via the HTML5
  form="doiupload" attribute, so it POSTs to /doiui_batch instead of the home page's
  GET search form; a styled label supplies the "Choose file of DOIs or PMIDs" text
  (native file inputs can't be relabeled) and shows the picked filename.
- Tokens split on whitespace OR commas (space-, newline-, tab-, and CSV lists all
  work); guards: 2 MB upload cap, 5000-id processing cap (with a truncation notice),
  and UTF-8-with-BOM / errors=replace decoding.

Bumps __version__ to 120.14.1.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

@stuarteberg