### PR TITLE
fix(ui): give each navbar dropdown a unique id (was all "navbarDropdown")

### DIFF
--- a/api/dis_html.py
+++ b/api/dis_html.py
@@ -410,10 +410,14 @@ def generate_navbar(active):
         basic = '<li class="nav-item active">' if heading == active else '<li class="nav-item">'
         drop = '<li class="nav-item dropdown active">' if heading == active \
                else '<li class="nav-item dropdown">'
-        menuhead = '<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" ' \
+        # Unique id per dropdown (there are ~9): a hardcoded id="navbarDropdown" on
+        # every one is invalid HTML and makes each menu's aria-labelledby resolve to
+        # the first toggle, so screen readers mislabel every menu.
+        did = "navbarDropdown-" + heading.lower().replace("/", "-").replace(" ", "-")
+        menuhead = f'<a class="nav-link dropdown-toggle" href="#" id="{did}" ' \
                    + 'role="button" data-toggle="dropdown" aria-haspopup="true" ' \
                    + f"aria-expanded=\"false\">{heading}</a><div class=\"dropdown-menu\" "\
-                   + 'aria-labelledby="navbarDropdown">'
+                   + f'aria-labelledby="{did}">'
         if subhead:
             nav += drop + menuhead
             nav += generate_navbar_items(subhead)

--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -48,7 +48,7 @@ from dis_state import CVTERM, PROJECT
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,too-many-lines,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
 
-__version__ = "120.15.0"
+__version__ = "120.15.1"
 # Database
 DB = {}
 INSENSITIVE = Collation(locale='en', strength=CollationStrength.PRIMARY)


### PR DESCRIPTION
generate_navbar() hardcoded id="navbarDropdown" (and a matching aria-labelledby) on every dropdown toggle, so each page rendered ~9 elements sharing that id - invalid HTML, and every dropdown menu's aria-labelledby resolved to the first toggle, so screen readers mislabelled every menu as "DOIs". Derive a unique id per heading (navbarDropdown-<slug>) and point each menu's aria-labelledby at its own toggle. No visual/behavioral change (Bootstrap dropdowns key off classes, not the id).

Bumps __version__ to 120.15.1.

@stuarteberg