### PR TITLE
style(ui): add vertical space above the "Find DOIs by organization" row

### DIFF
--- a/api/templates/home.html
+++ b/api/templates/home.html
@@ -201,7 +201,7 @@ onload="tableInitialize();"
   {{ projects | safe }}
 </datalist>
 <br>
-<div class="flexcontainer">
+<div class="flexcontainer" style="margin-top: 24px;">
   <div class="flexitem">
   <span class="form-control-lg">Find DOIs by organization:</span>
   </div>


### PR DESCRIPTION
Give the organization row a 24px top margin so the consolidated "Find DOIs by" pulldown control reads as visually separate from the organization row below it.

home.html only; no __version__ bump on purpose - this rides parallel to the unmerged navbar-dropdown-id branch (which bumps to 120.15.1), and bumping both would collide on the version line for a one-line cosmetic change.