### PR TITLE
feat(ui): show a retraction banner on /doiui for jrc_retracted records

### DIFF
--- a/api/dis_responder.py
+++ b/api/dis_responder.py
@@ -48,7 +48,7 @@ from dis_state import CVTERM, PROJECT
 
 # pylint: disable=broad-exception-caught,broad-exception-raised,too-many-lines,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
 
-__version__ = "120.17.0"
+__version__ = "120.17.2"
 # Database
 DB = {}
 INSENSITIVE = Collation(locale='en', strength=CollationStrength.PRIMARY)
@@ -5445,9 +5445,16 @@ def show_doi_ui(doi):
     else:
         doititle = doilink
     doititle += badges
+    # Retraction banner: shown above the DOI line when the record is flagged retracted.
+    banner = ""
+    if row and row.get('jrc_retracted'):
+        banner = ("<div class='retracted-banner'><i class='fa-solid fa-ban'></i>"
+                  "<strong>Retracted</strong> &mdash; this publication has been "
+                  "retracted.</div>")
     endpoint_access()
     return make_response(render_template('doi.html', urlroot=request.url_root, pagetitle=doi,
-                                         title=doititle, recsec=recsec, #doisec=doisec,
+                                         title=doititle, banner=banner, recsec=recsec,
+                                         #doisec=doisec,
                                          cittype=cittype, citsec=citsec,
                                          html=html,
                                          navbar=generate_navbar('DOIs')))

--- a/api/static/css/main.css
+++ b/api/static/css/main.css
@@ -554,6 +554,22 @@ hr {border-color: var(--muted-border);
    color: white;
    background-color: #0000b0;
 }
+.retracted-banner {
+  background-color: rgba(192, 57, 43, 0.18);
+  border-left: 5px solid #c0392b;
+  border-radius: 4px;
+  padding: 10px 14px;
+  margin-bottom: 14px;
+  color: #f1a9a0;
+  font-size: 1.2rem;
+}
+.retracted-banner i {
+  color: #e74c3c;
+  margin-right: 8px;
+}
+.retracted-banner strong {
+  color: #e74c3c;
+}
 
 .tag-chip {
   display: inline-block;

--- a/api/templates/doi.html
+++ b/api/templates/doi.html
@@ -7,6 +7,7 @@ onload="tableInitialize();"
 {% endblock %}
 
 {% block content %}
+  {% if banner %}{{ banner|safe }}{% endif %}
   <h2>{{title|safe}}</h2>
   {{ recsec|safe }}
   {{ doisec|safe }}


### PR DESCRIPTION
When a DOI record has a truthy jrc_retracted, render a banner above the DOI line (the DOI link + copy icon + PMID + pills) on the /doiui page. Noticeable but not garish: a translucent-red callout (.retracted-banner) with a crimson left border, a ban icon, and a bold "Retracted" label. Passed to doi.html as a new `banner` var, which is empty (and the block is skipped) for non-retracted records.

Bumps __version__ to 120.17.2.

@stuarteberg